### PR TITLE
[WIP] dsl for services registration

### DIFF
--- a/Swinject/Assembly.swift
+++ b/Swinject/Assembly.swift
@@ -1,0 +1,43 @@
+//
+//  Assembly.swift
+//  Swinject
+//
+//  Created by Иван Ушаков on 11.10.15.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public class Assembly
+{
+    internal var container: Container
+    
+    required public init(container: Container)
+    {
+        self.container = container;
+        create()
+    }
+    
+    public func create()
+    {
+        fatalError("You should implement create method of assembly");
+    }
+    
+    public func register<Service>(
+        serviceType: Service.Type,
+        name: String? = nil,
+        definitionAssembly:(Definition<Service> -> Void)) -> (Void -> Service)
+    {
+        let definition = Definition<Service>(serviceType)
+        definitionAssembly(definition)
+        container.register(definition)
+        
+        return {
+            guard let service = self.container.resolve(serviceType) else {
+                fatalError("Service \(serviceType) con not be  resloved")
+            }
+            
+            return service
+        };
+    }
+}

--- a/Swinject/Container.swift
+++ b/Swinject/Container.swift
@@ -42,6 +42,15 @@ public final class Container {
         self.parent = parent
     }
     
+    /// Instantiates a `Container` and register services from assemblies.
+    ///
+    /// - Parameter assemblies: Assemblies from which will be registered services.
+    public convenience init(assemblies: [Assembly.Type])
+    {
+        self.init()
+        assemblies.forEach { registerAssembly($0) }
+    }
+    
     /// Removes all registrations in the container.
     public func removeAll() {
         services.removeAll()
@@ -72,6 +81,32 @@ public final class Container {
         let entry = ServiceEntry(serviceType: serviceType, factory: factory)
         services[key] = entry
         return entry
+    }
+    
+    /// Adds a registration for the services from `Assembly` in which specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - assembly:    `Assembly` from which will be registered services.
+    public func registerAssembly<A:Assembly>(assembly: A.Type)
+    {
+        assembly.init(container: self)
+    }
+    
+    /// Adds a registration for the services from `Definition`.
+    ///
+    /// - Parameters:
+    ///   - definition:    `Definition` for service.
+    internal func register<Service>(definition: Definition<Service>)
+    {
+        guard let initializer = definition.initializer else {
+            fatalError("You should define initializer for \(definition.serviceType)")
+        }
+        
+        let service = register(definition.serviceType, factory: initializer).inObjectScope(definition.scope)
+        
+        if let complited = definition.complited {
+            service.initCompleted(complited)
+        }
     }
 }
 

--- a/Swinject/Definition.swift
+++ b/Swinject/Definition.swift
@@ -1,0 +1,32 @@
+//
+//  Definition.swift
+//  Swinject
+//
+//  Created by Иван Ушаков on 11.10.15.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public class Definition<Service>
+{
+    typealias FactoryType = Resolvable -> Service
+    typealias ComplitedType = (Resolvable, Service) -> Void
+    
+    internal let serviceType: Service.Type
+    internal var initializer: FactoryType?;
+    internal var complited: ComplitedType?;
+    var scope: ObjectScope = ObjectScope.Graph;
+    
+    init(_ serviceType: Service.Type) {
+        self.serviceType = serviceType
+    }
+    
+    public func initialize(initializer:(Resolvable -> Service)) {
+        self.initializer = initializer
+    }
+    
+    public func complite(complited: (Resolvable, Service) -> Void) {
+        self.complited = complited
+    }
+}


### PR DESCRIPTION
I really like assemblies in Typhoon. It allow you to see the whole hierarchy of dependencies in one place. I start work on this, but it does not ready to use yet. Later, I will add some documentation and tests. 

First of all I would like know, did you interested in this?

```
class ServiceAssembly: Assembly
{
    override func create()
    {
        let baseUrl = "http://perpetuumlab.com/api/v1/"
        
        let httpClient = register(HTTPClient.self) { d in
            d.initialize { _ in HTTPClientImpl(baseUrl: baseUrl) }
            d.scope = ObjectScope.Hierarchy
        }
        
        _ = register(MainInfoApiClient.self) { d in
            d.initialize { _ in MainInfoApiClientImp(httpClient: httpClient()) }
            d.scope = ObjectScope.Hierarchy
        }
        
        _ = register(TeammatesApiClient.self) { d in
            d.initialize { _ in TeammatesApiClientImpl(httpClient: httpClient()) }
            d.scope = ObjectScope.Hierarchy
        }
        
        _ = register(ProjectApiClient.self) { d in
            d.initialize { _ in ProjectApiClientImpl(httpClient: httpClient()) }
            d.scope = ObjectScope.Hierarchy
        }
    }
}
```