### PR TITLE
New method signatures

### DIFF
--- a/Documentation/DIContainer.md
+++ b/Documentation/DIContainer.md
@@ -92,24 +92,38 @@ Where `Dog` class is:
 
 ## Registration with Arguments to DI Container
 
-Arguments can be passed from a caller of `resolve` method to a factory. The factory can take generic arguments. Here is an example.
+A factory closure to register a service can take arguments that are passed when the service is resolved. When you register the service, the arguments can be specified after the `Resolvable` parameter (in the following example, it is unused as `_`).
 
-    container.register(AnimalType.self) { _, arg1, arg2 in
-        Horse(name: arg1, running: arg2)
+    container.register(AnimalType.self) { _, name in
+        Horse(name: name)
+    }
+    container.register(AnimalType.self) { _, name, running in
+        Horse(name: name, running: running)
     }
 
-Then specify the arguments when you call `resolve` method.
+Then pass runtime arguments when you call `resolve` method. If you pass only 1 argument, use `resolve(_:argument:)`.
 
-    let animal = container.resolve(AnimalType.self, arg1: "Lucky", arg2: true)!
+    let animal1 = container.resolve(AnimalType.self, argument: "Spirit")!
 
-    print(animal.name) // prints "Lucky"
-    print((animal as! Horse).running) // prints "true"
+    print(animal1.name) // prints "Spirit"
+    print((animal1 as! Horse).running) // prints "false"
+
+If you pass 2 arguments or more, use `resolve(_:arguments:)` where the arguments are passed as a tuple.
+
+    let animal2 = container.resolve(AnimalType.self, arguments: ("Lucky", true))!
+
+    print(animal2.name) // prints "Lucky"
+    print((animal2 as! Horse).running) // prints "true"
 
 Where the `Horse` class is:
 
     class Horse: AnimalType {
         let name: String
         let running: Bool
+
+        convenience init(name: String) {
+            self.init(name: name, running: false)
+        }
 
         init(name: String, running: Bool) {
             self.name = name
@@ -141,18 +155,18 @@ The following registrations can co-exist in a container because the registration
     container.register(AnimalType.self, name: "cat") { _ in Cat(name: "Mimi") }
     container.register(AnimalType.self, name: "dog") { _ in Dog(name: "Hachi") }
 
-The following registrations can co-exist in a container because the numbers of arguments are different.
+The following registrations can co-exist in a container because the numbers of arguments are different. The first registration has no arguments, and the second has an argument.
 
     container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
-    container.register(AnimalType.self) { _, arg1 in Cat(name: arg1) }
+    container.register(AnimalType.self) { _, name in Cat(name: name) }
 
-The following registrations can co-exist in a container because the types of arguments are different. (The first registration has `String` and `Bool` types. The second registration has `Bool` and `String` types in the order.)
+The following registrations can co-exist in a container because the types of arguments are different. The first registration has `String` and `Bool` types. The second registration has `Bool` and `String` types in the order.
 
-    container.register(AnimalType.self) { _, arg1, arg2 in
-        Horse(name: arg1, running: arg2)
+    container.register(AnimalType.self) { _, name, running in
+        Horse(name: name, running: running)
     }
-    container.register(AnimalType.self) { _, arg1, arg2 in
-        Horse(name: arg2, running: arg1)
+    container.register(AnimalType.self) { _, running, name in
+        Horse(name: name, running: running)
     }
 
 _[Next page: Injection Patterns](InjectionPatterns.md)_

--- a/Sample-iOS.playground/Contents.swift
+++ b/Sample-iOS.playground/Contents.swift
@@ -205,8 +205,12 @@ print(parent === child.parent)
 
 class Horse: AnimalType {
     var name: String?
-    var running = false
+    var running: Bool
     
+    convenience init(name: String) {
+        self.init(name: name, running: false)
+    }
+
     init(name: String, running: Bool) {
         self.name = name
         self.running = running
@@ -217,15 +221,22 @@ class Horse: AnimalType {
     }
 }
 
-// The factory closure can take arguments.
+// The factory closure can take arguments after the `Resolvable` parameter (in this example, unused as `_`).
 // Note that the container already has an AnimalType without a registration name,
 // but the factory with the arguments is recognized as a different registration to resolve.
-container.register(AnimalType.self) { _, arg1, arg2 in Horse(name: arg1, running: arg2) }
+container.register(AnimalType.self) { _, name in Horse(name: name) }
+container.register(AnimalType.self) { _, name, running in Horse(name: name, running: running) }
 
 // The arguments to the factory are specified on the resolution.
-let horse = container.resolve(AnimalType.self, arg1: "Lucky", arg2: true) as! Horse
-print(horse.name!)
-print(horse.running)
+// If you pass an argument, pass it to `argument` parameter.
+// If you pass more arguments, pass them as a tuple to `arguments` parameter.
+let horse1 = container.resolve(AnimalType.self, argument: "Spirit") as! Horse
+print(horse1.name)
+print(horse1.running)
+
+let horse2 = container.resolve(AnimalType.self, arguments: ("Lucky", true)) as! Horse
+print(horse2.name)
+print(horse2.running)
 
 /*:
 ## Self-binding

--- a/Sample-iOS.playground/contents.xcplayground
+++ b/Sample-iOS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' requires-full-environment='true' display-mode='rendered'>
+<playground version='5.0' target-platform='ios' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Swinject/Container.Arguments.erb
+++ b/Swinject/Container.Arguments.erb
@@ -15,7 +15,6 @@
 //
 
 <% arg_count = 12 %>
-<% argument_text = lambda { |n| n == 1 ? "#{n} argument" : "#{n} arguments" } %>
 
 import Foundation
 
@@ -23,6 +22,7 @@ import Foundation
 extension Container {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_description = i == 1 ? "#{i} argument" : "#{i} arguments" %>
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
@@ -31,7 +31,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and <%= argument_text.call(i) %> to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and <%= arg_description %> to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -50,40 +50,37 @@ extension Container {
 extension Container {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
-<%   arg_params = (1..i).map { |n| "arg#{n}: Arg#{n}" }.join(", ") %>
-<%   args_passed = (1..i).map { |n| "arg#{n}: arg#{n}" }.join(", ") %>
-<%   args_factory = (1..i).map { |n| "arg#{n}" }.join(", ") %>
-    /// Retrieves the instance with the specified service type and <%= argument_text.call(i) %> to the factory closure.
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_type = i == 1 ? arg_types : "(" + arg_types + ")" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "tuple of #{i} arguments" %>
+<%   args_factory = i == 1 ? "argument" : (1..i).map { |n| "arguments.#{n-1}" }.join(", ") %>
+    /// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-<%   (1..i).each do |n| %>
-    ///   - arg<%= n %>:        An argument to the factory closure as Arg<%= n %> type.
-<%   end %>
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and <%= argument_text.call(i) %> is found in the `Container`.
+    ///            and <%= arg_param_description %> is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_params %>) -> Service?
+        <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
     {
-        return resolve(serviceType, <%= args_passed %>, name: nil)
+        return resolve(serviceType, <%= arg_param_name %>: <%= arg_param_name %>, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, <%= argument_text.call(i) %> to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-<%   (1..i).each do |n| %>
-    ///   - arg<%= n %>:        An argument to the factory closure as Arg<%= n %> type.
-<%   end %>
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            <%= argument_text.call(i) %> and name is found in the `Container`.
+    ///            <%= arg_param_description %> and name is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_params %>,
+        <%= arg_param_name %>: <%= arg_param_type %>,
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, <%= arg_types %>) -> Service

--- a/Swinject/Container.Arguments.swift
+++ b/Swinject/Container.Arguments.swift
@@ -27,7 +27,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 1 argument to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 1 argument to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -47,7 +47,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 2 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 2 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -67,7 +67,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 3 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 3 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -87,7 +87,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 4 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 4 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -107,7 +107,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 5 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 5 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -127,7 +127,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 6 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 6 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -147,7 +147,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 7 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 7 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -167,7 +167,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 8 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 8 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -187,7 +187,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 9 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 9 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -207,7 +207,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 10 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 10 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -227,7 +227,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 11 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 11 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -247,7 +247,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolvable` and 12 arguments to inject dependencies to the instance,
+    ///                  It takes a `Resolvable` instance and 12 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure some settings fluently.
@@ -267,528 +267,396 @@ extension Container {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
     ///            and 1 argument is found in the `Container`.
     public func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        arg1: Arg1) -> Service?
+        argument: Arg1) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, name: nil)
+        return resolve(serviceType, argument: argument, name: nil)
     }
 
     /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            1 argument and name is found in the `Container`.
     public func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        arg1: Arg1,
+        argument: Arg1,
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, argument) }
     }
 
-    /// Retrieves the instance with the specified service type and 2 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 2 arguments is found in the `Container`.
+    ///            and tuple of 2 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2) -> Service?
+        arguments: (Arg1, Arg2)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 2 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            2 arguments and name is found in the `Container`.
+    ///            tuple of 2 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2,
+        arguments: (Arg1, Arg2),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1) }
     }
 
-    /// Retrieves the instance with the specified service type and 3 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 3 arguments is found in the `Container`.
+    ///            and tuple of 3 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3) -> Service?
+        arguments: (Arg1, Arg2, Arg3)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 3 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            3 arguments and name is found in the `Container`.
+    ///            tuple of 3 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3,
+        arguments: (Arg1, Arg2, Arg3),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2) }
     }
 
-    /// Retrieves the instance with the specified service type and 4 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 4 arguments is found in the `Container`.
+    ///            and tuple of 4 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 4 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            4 arguments and name is found in the `Container`.
+    ///            tuple of 4 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4,
+        arguments: (Arg1, Arg2, Arg3, Arg4),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3) }
     }
 
-    /// Retrieves the instance with the specified service type and 5 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 5 arguments is found in the `Container`.
+    ///            and tuple of 5 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 5 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            5 arguments and name is found in the `Container`.
+    ///            tuple of 5 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4) }
     }
 
-    /// Retrieves the instance with the specified service type and 6 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 6 arguments is found in the `Container`.
+    ///            and tuple of 6 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 6 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            6 arguments and name is found in the `Container`.
+    ///            tuple of 6 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5) }
     }
 
-    /// Retrieves the instance with the specified service type and 7 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 7 arguments is found in the `Container`.
+    ///            and tuple of 7 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 7 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            7 arguments and name is found in the `Container`.
+    ///            tuple of 7 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6) }
     }
 
-    /// Retrieves the instance with the specified service type and 8 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 8 arguments is found in the `Container`.
+    ///            and tuple of 8 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, arg8: arg8, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 8 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            8 arguments and name is found in the `Container`.
+    ///            tuple of 8 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7) }
     }
 
-    /// Retrieves the instance with the specified service type and 9 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 9 arguments is found in the `Container`.
+    ///            and tuple of 9 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, arg8: arg8, arg9: arg9, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 9 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            9 arguments and name is found in the `Container`.
+    ///            tuple of 9 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8) }
     }
 
-    /// Retrieves the instance with the specified service type and 10 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 10 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 10 arguments is found in the `Container`.
+    ///            and tuple of 10 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, arg8: arg8, arg9: arg9, arg10: arg10, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 10 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 10 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            10 arguments and name is found in the `Container`.
+    ///            tuple of 10 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9) }
     }
 
-    /// Retrieves the instance with the specified service type and 11 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 11 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 11 arguments is found in the `Container`.
+    ///            and tuple of 11 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, arg8: arg8, arg9: arg9, arg10: arg10, arg11: arg11, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 11 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 11 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            11 arguments and name is found in the `Container`.
+    ///            tuple of 11 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9, arguments.10) }
     }
 
-    /// Retrieves the instance with the specified service type and 12 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 12 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
-    ///   - arg12:        An argument to the factory closure as Arg12 type.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 12 arguments is found in the `Container`.
+    ///            and tuple of 12 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11, arg12: Arg12) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
     {
-        return resolve(serviceType, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6, arg7: arg7, arg8: arg8, arg9: arg9, arg10: arg10, arg11: arg11, arg12: arg12, name: nil)
+        return resolve(serviceType, arguments: arguments, name: nil)
     }
 
-    /// Retrieves the instance with the specified service type, 12 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 12 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
-    ///   - arg12:        An argument to the factory closure as Arg12 type.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            12 arguments and name is found in the `Container`.
+    ///            tuple of 12 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11, arg12: Arg12,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12),
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12) -> Service
-        return resolveImpl(name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) }
+        return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9, arguments.10, arguments.11) }
     }
 
 }

--- a/Swinject/Resolvable.erb
+++ b/Swinject/Resolvable.erb
@@ -15,7 +15,6 @@
 //
 
 <% arg_count = 12 %>
-<% argument_text = lambda { |n| n == 1 ? "#{n} argument" : "#{n} arguments" } %>
 
 public protocol Resolvable {
     /// Retrieves the instance with the specified service type.
@@ -36,35 +35,33 @@ public protocol Resolvable {
 
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
-<%   arg_params = (1..i).map { |n| "arg#{n}: Arg#{n}" }.join(", ") %>
-    /// Retrieves the instance with the specified service type and <%= argument_text.call(i) %> to the factory closure.
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_type = i == 1 ? arg_types : "(" + arg_types + ")" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "tuple of #{i} arguments" %>
+    /// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-<%   (1..i).each do |n| %>
-    ///   - arg<%= n %>:        An argument to the factory closure as Arg<%= n %> type.
-<%   end %>
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and <%= argument_text.call(i) %> is found.
+    ///            and <%= arg_param_description %> is found.
     func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_params %>) -> Service?
+        <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
 
-    /// Retrieves the instance with the specified service type, <%= argument_text.call(i) %> to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-<%   (1..i).each do |n| %>
-    ///   - arg<%= n %>:        An argument to the factory closure as Arg<%= n %> type.
-<%   end %>
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            <%= argument_text.call(i) %> and name is found.
+    ///            <%= arg_param_description %> and name is found.
     func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_params %>,
+        <%= arg_param_name %>: <%= arg_param_type %>,
         name: String?) -> Service?
 
 <% end %>

--- a/Swinject/Resolvable.swift
+++ b/Swinject/Resolvable.swift
@@ -36,444 +36,312 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
     ///            and 1 argument is found.
     func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        arg1: Arg1) -> Service?
+        argument: Arg1) -> Service?
 
     /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            1 argument and name is found.
     func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        arg1: Arg1,
+        argument: Arg1,
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 2 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 2 arguments is found.
+    ///            and tuple of 2 arguments is found.
     func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2) -> Service?
+        arguments: (Arg1, Arg2)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 2 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            2 arguments and name is found.
+    ///            tuple of 2 arguments and name is found.
     func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2,
+        arguments: (Arg1, Arg2),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 3 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 3 arguments is found.
+    ///            and tuple of 3 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3) -> Service?
+        arguments: (Arg1, Arg2, Arg3)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 3 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            3 arguments and name is found.
+    ///            tuple of 3 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3,
+        arguments: (Arg1, Arg2, Arg3),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 4 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 4 arguments is found.
+    ///            and tuple of 4 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 4 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            4 arguments and name is found.
+    ///            tuple of 4 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4,
+        arguments: (Arg1, Arg2, Arg3, Arg4),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 5 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 5 arguments is found.
+    ///            and tuple of 5 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 5 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            5 arguments and name is found.
+    ///            tuple of 5 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 6 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 6 arguments is found.
+    ///            and tuple of 6 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 6 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            6 arguments and name is found.
+    ///            tuple of 6 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 7 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 7 arguments is found.
+    ///            and tuple of 7 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 7 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            7 arguments and name is found.
+    ///            tuple of 7 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 8 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 8 arguments is found.
+    ///            and tuple of 8 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 8 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            8 arguments and name is found.
+    ///            tuple of 8 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 9 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 9 arguments is found.
+    ///            and tuple of 9 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 9 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            9 arguments and name is found.
+    ///            tuple of 9 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 10 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 10 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 10 arguments is found.
+    ///            and tuple of 10 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 10 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 10 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            10 arguments and name is found.
+    ///            tuple of 10 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 11 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 11 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 11 arguments is found.
+    ///            and tuple of 11 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 11 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 11 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            11 arguments and name is found.
+    ///            tuple of 11 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11),
         name: String?) -> Service?
 
-    /// Retrieves the instance with the specified service type and 12 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and tuple of 12 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
-    ///   - arg12:        An argument to the factory closure as Arg12 type.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 12 arguments is found.
+    ///            and tuple of 12 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11, arg12: Arg12) -> Service?
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
 
-    /// Retrieves the instance with the specified service type, 12 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, tuple of 12 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arg1:        An argument to the factory closure as Arg1 type.
-    ///   - arg2:        An argument to the factory closure as Arg2 type.
-    ///   - arg3:        An argument to the factory closure as Arg3 type.
-    ///   - arg4:        An argument to the factory closure as Arg4 type.
-    ///   - arg5:        An argument to the factory closure as Arg5 type.
-    ///   - arg6:        An argument to the factory closure as Arg6 type.
-    ///   - arg7:        An argument to the factory closure as Arg7 type.
-    ///   - arg8:        An argument to the factory closure as Arg8 type.
-    ///   - arg9:        An argument to the factory closure as Arg9 type.
-    ///   - arg10:        An argument to the factory closure as Arg10 type.
-    ///   - arg11:        An argument to the factory closure as Arg11 type.
-    ///   - arg12:        An argument to the factory closure as Arg12 type.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            12 arguments and name is found.
+    ///            tuple of 12 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9, arg10: Arg10, arg11: Arg11, arg12: Arg12,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12),
         name: String?) -> Service?
 
 }

--- a/SwinjectTests/ContainerSpec.Arguments.swift
+++ b/SwinjectTests/ContainerSpec.Arguments.swift
@@ -23,7 +23,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1")!
+                argument: "1")!
             expect(animal.name) == "1"
         }
         it("accepts 2 arguments.") {
@@ -32,7 +32,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2")!
+                arguments: ("1", "2"))!
             expect(animal.name) == "12"
         }
         it("accepts 3 arguments.") {
@@ -41,7 +41,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3")!
+                arguments: ("1", "2", "3"))!
             expect(animal.name) == "123"
         }
         it("accepts 4 arguments.") {
@@ -50,7 +50,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4")!
+                arguments: ("1", "2", "3", "4"))!
             expect(animal.name) == "1234"
         }
         it("accepts 5 arguments.") {
@@ -59,7 +59,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5")!
+                arguments: ("1", "2", "3", "4", "5"))!
             expect(animal.name) == "12345"
         }
         it("accepts 6 arguments.") {
@@ -68,7 +68,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6")!
+                arguments: ("1", "2", "3", "4", "5", "6"))!
             expect(animal.name) == "123456"
         }
         it("accepts 7 arguments.") {
@@ -77,7 +77,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7"))!
             expect(animal.name) == "1234567"
         }
         it("accepts 8 arguments.") {
@@ -86,7 +86,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7", arg8: "8")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7", "8"))!
             expect(animal.name) == "12345678"
         }
         it("accepts 9 arguments.") {
@@ -95,7 +95,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7", arg8: "8", arg9: "9")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7", "8", "9"))!
             expect(animal.name) == "123456789"
         }
         it("accepts 10 arguments.") {
@@ -104,7 +104,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7", arg8: "8", arg9: "9", arg10: "A")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7", "8", "9", "A"))!
             expect(animal.name) == "123456789A"
         }
         it("accepts 11 arguments.") {
@@ -113,7 +113,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7", arg8: "8", arg9: "9", arg10: "A", arg11: "B")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B"))!
             expect(animal.name) == "123456789AB"
         }
         it("accepts 12 arguments.") {
@@ -122,7 +122,7 @@ class ContainerSpec_Arguments: QuickSpec {
             }
             let animal = container.resolve(
                 AnimalType.self,
-                arg1: "1", arg2: "2", arg3: "3", arg4: "4", arg5: "5", arg6: "6", arg7: "7", arg8: "8", arg9: "9", arg10: "A", arg11: "B", arg12: "C")!
+                arguments: ("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C"))!
             expect(animal.name) == "123456789ABC"
         }
     }

--- a/SwinjectTests/ContainerSpec.swift
+++ b/SwinjectTests/ContainerSpec.swift
@@ -30,8 +30,8 @@ class ContainerSpec: QuickSpec {
                 container.register(AnimalType.self) { _, arg1, arg2 in Cat(name: arg1, sleeping: arg2) }
                 
                 let noname = container.resolve(AnimalType.self) as! Cat
-                let mimi = container.resolve(AnimalType.self, arg1: "Mimi") as! Cat
-                let mew = container.resolve(AnimalType.self, arg1: "Mew", arg2: true) as! Cat
+                let mimi = container.resolve(AnimalType.self, argument: "Mimi") as! Cat
+                let mew = container.resolve(AnimalType.self, arguments: ("Mew", true)) as! Cat
                 expect(noname.name).to(beNil())
                 expect(mimi.name) == "Mimi"
                 expect(mew.name) == "Mew"


### PR DESCRIPTION
Change the signatures of `resolve` methods taking arguments for a better readability.

- For 1 argument: `resolve(_:argument:)`
- For 2 or more arguments: `resolve(_:arguments:)`