### PR TITLE
Add note about register for storyboard

### DIFF
--- a/Documentation/Storyboard.md
+++ b/Documentation/Storyboard.md
@@ -2,6 +2,8 @@
 
 Swinject supports dependency injection to view controllers instantiated by `SwinjectStoryboard`, which inherits `UIStoryboard` (or `NSStoryboard` in case of OS X). To register dependencies of a view controller, use `registerForStoryboard` method. In the same way as a registration of a service type, a view controller can be registered with or without a name.
 
+**Note**: Do **NOT** explicitly resolve the view controllers registered by `registerForStoryboard` method. The view controllers are intended to be resolved by `SwinjectStoryboard` implicitly.
+
 ## Registration
 
 ### Registration without Name

--- a/Swinject/Container.swift
+++ b/Swinject/Container.swift
@@ -82,6 +82,9 @@ public final class Container {
 extension Container {
     /// Adds a registration of the specified view or window controller that is configured in a storyboard.
     ///
+    /// - Note: Do NOT explicitly resolve the controller registered by this method.
+    ///         The controller is intended to be resolved by `SwinjectStoryboard` implicitly.
+    ///
     /// - Parameters:
     ///   - controllerType: The controller type to register as a service type.
     ///                     The type is `UIViewController` in iOS, `NSViewController` or `NSWindowController` in OS X.


### PR DESCRIPTION
Added some notes about `registerForStoryboard` method for Issue #18.

The issue requested to change the method name, but only documentation has been updated. If a trailing closure is not used, the closure is supplied to `initCompleted` parameter, and the parameter name is shown in Xcode by `Option-Click` on the method name. The method name is minimal, and only the documentation looks sufficient to guide users to use the method.