### PR TITLE
Change the signature of resolve method for consistency

### DIFF
--- a/Swinject/Container.Arguments.erb
+++ b/Swinject/Container.Arguments.erb
@@ -66,22 +66,22 @@ extension Container {
         serviceType: Service.Type,
         <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
     {
-        return resolve(serviceType, <%= arg_param_name %>: <%= arg_param_name %>, name: nil)
+        return resolve(serviceType, name: nil, <%= arg_param_name %>: <%= arg_param_name %>)
     }
 
     /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            <%= arg_param_description %> and name is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_param_name %>: <%= arg_param_type %>,
-        name: String?) -> Service?
+        name: String?,
+        <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
     {
         typealias FactoryType = (Resolvable, <%= arg_types %>) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, <%= args_factory %>) }

--- a/Swinject/Container.Arguments.swift
+++ b/Swinject/Container.Arguments.swift
@@ -275,22 +275,22 @@ extension Container {
         serviceType: Service.Type,
         argument: Arg1) -> Service?
     {
-        return resolve(serviceType, argument: argument, name: nil)
+        return resolve(serviceType, name: nil, argument: argument)
     }
 
     /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - argument:   1 argument to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            1 argument and name is found in the `Container`.
     public func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        argument: Arg1,
-        name: String?) -> Service?
+        name: String?,
+        argument: Arg1) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, argument) }
@@ -308,22 +308,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 2 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1) }
@@ -341,22 +341,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 3 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2) }
@@ -374,22 +374,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 4 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3) }
@@ -407,22 +407,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 5 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4) }
@@ -440,22 +440,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 6 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5) }
@@ -473,22 +473,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 7 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6) }
@@ -506,22 +506,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 8 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7) }
@@ -539,22 +539,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 9 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8) }
@@ -572,22 +572,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 10 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 10 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9) }
@@ -605,22 +605,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 11 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 11 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9, arguments.10) }
@@ -638,22 +638,22 @@ extension Container {
         serviceType: Service.Type,
         arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
     {
-        return resolve(serviceType, arguments: arguments, name: nil)
+        return resolve(serviceType, name: nil, arguments: arguments)
     }
 
     /// Retrieves the instance with the specified service type, tuple of 12 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 12 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
     {
         typealias FactoryType = (Resolvable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12) -> Service
         return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8, arguments.9, arguments.10, arguments.11) }

--- a/Swinject/OSX/SwinjectStoryboard.swift
+++ b/Swinject/OSX/SwinjectStoryboard.swift
@@ -91,7 +91,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
         // If a future update of Xcode fixes the problem, replace the resolution with the following code and fix registerForStoryboard too:
         //    container.resolve(controller.dynamicType, argument: viewController as Container.Controller, name: registrationName)
         let nameWithActualType = String(reflecting: controller.dynamicType) + ":" + (registrationName ?? "")
-        container.value.resolve(Container.Controller.self, argument: controller as Container.Controller, name: nameWithActualType)
+        container.value.resolve(Container.Controller.self, name: nameWithActualType, argument: controller as Container.Controller)
         
         if let viewController = controller as? NSViewController {
             for child in viewController.childViewControllers {

--- a/Swinject/Resolvable.erb
+++ b/Swinject/Resolvable.erb
@@ -54,15 +54,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            <%= arg_param_description %> and name is found.
     func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_param_name %>: <%= arg_param_type %>,
-        name: String?) -> Service?
+        name: String?,
+        <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
 
 <% end %>
 }

--- a/Swinject/Resolvable.swift
+++ b/Swinject/Resolvable.swift
@@ -48,15 +48,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - argument:   1 argument to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            1 argument and name is found.
     func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        argument: Arg1,
-        name: String?) -> Service?
+        name: String?,
+        argument: Arg1) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
     ///
@@ -74,15 +74,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 2 arguments and name is found.
     func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
     ///
@@ -100,15 +100,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 3 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
     ///
@@ -126,15 +126,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 4 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
     ///
@@ -152,15 +152,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 5 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
     ///
@@ -178,15 +178,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 6 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
     ///
@@ -204,15 +204,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 7 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
     ///
@@ -230,15 +230,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 8 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
     ///
@@ -256,15 +256,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 9 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 10 arguments to the factory closure.
     ///
@@ -282,15 +282,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 10 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 10 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 11 arguments to the factory closure.
     ///
@@ -308,15 +308,15 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 11 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 11 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
 
     /// Retrieves the instance with the specified service type and tuple of 12 arguments to the factory closure.
     ///
@@ -334,14 +334,14 @@ public protocol Resolvable {
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///   - name:        The registration name.
+    ///   - arguments:   Tuple of 12 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            tuple of 12 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
 
 }

--- a/Swinject/SynchronizedResolver.Arguments.erb
+++ b/Swinject/SynchronizedResolver.Arguments.erb
@@ -33,11 +33,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, <%= arg_types %>>(
         serviceType: Service.Type,
-        <%= arg_param_name %>: <%= arg_param_type %>,
-        name: String?) -> Service?
+        name: String?,
+        <%= arg_param_name %>: <%= arg_param_type %>) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, <%= arg_param_name %>: <%= arg_param_name %>, name: name)
+            return self.container.resolve(serviceType, name: name, <%= arg_param_name %>: <%= arg_param_name %>)
         }
     }
 

--- a/Swinject/SynchronizedResolver.Arguments.swift
+++ b/Swinject/SynchronizedResolver.Arguments.swift
@@ -28,11 +28,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1>(
         serviceType: Service.Type,
-        argument: Arg1,
-        name: String?) -> Service?
+        name: String?,
+        argument: Arg1) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, argument: argument, name: name)
+            return self.container.resolve(serviceType, name: name, argument: argument)
         }
     }
 
@@ -47,11 +47,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -66,11 +66,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -85,11 +85,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -104,11 +104,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -123,11 +123,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -142,11 +142,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -161,11 +161,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -180,11 +180,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -199,11 +199,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -218,11 +218,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 
@@ -237,11 +237,11 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(
         serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12),
-        name: String?) -> Service?
+        name: String?,
+        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12)) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments, name: name)
+            return self.container.resolve(serviceType, name: name, arguments: arguments)
         }
     }
 

--- a/Swinject/iOS-tvOS/SwinjectStoryboard.swift
+++ b/Swinject/iOS-tvOS/SwinjectStoryboard.swift
@@ -91,7 +91,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
         // If a future update of Xcode fixes the problem, replace the resolution with the following code and fix registerForStoryboard too:
         //    container.resolve(viewController.dynamicType, argument: viewController as Container.Controller, name: registrationName)
         let nameWithActualType = String(reflecting: viewController.dynamicType) + ":" + (registrationName ?? "")
-        container.value.resolve(Container.Controller.self, argument: viewController as Container.Controller, name: nameWithActualType)
+        container.value.resolve(Container.Controller.self, name: nameWithActualType, argument: viewController as Container.Controller)
         
         for child in viewController.childViewControllers {
             injectDependency(child)


### PR DESCRIPTION
Change the signature of `resolve` method from `resolve(_:arguments:name:)` to `resolve(_:name:arguments:)` for consistency with `register` method.