### PR TITLE
Fix Hound-Swift setting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,10 @@
 disabled_rules:
   - force_cast
+  - line_length
   - variable_name_min_length
   - trailing_whitespace
   - nesting
   - opening_brace
-line_length: 140
 excluded:
   - Swinject/Container.Arguments.swift
   - Swinject/SynchronizedResolver.Arguments.swift


### PR DESCRIPTION
Disabled `line_length` rule of SwiftLint because the length setting does not work sometimes on Hound CI.