### PR TITLE
Refactoring to remove unnecessary inheritance of ServiceEntry type

### DIFF
--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -128,6 +128,10 @@
 		987DD0EB1BBFE6DA006572A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98689CCE1BBFDCCD0005C6D3 /* Quick.framework */; };
 		987DD0EC1BBFE6E2006572A2 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 98689CCD1BBFDCCD0005C6D3 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		987DD0ED1BBFE6E2006572A2 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 98689CCE1BBFDCCD0005C6D3 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9880E70E1C09EE2900ED5293 /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9880E70D1C09EE2800ED5293 /* FunctionType.swift */; };
+		9880E70F1C09EE2900ED5293 /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9880E70D1C09EE2800ED5293 /* FunctionType.swift */; };
+		9880E7101C09EE2900ED5293 /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9880E70D1C09EE2800ED5293 /* FunctionType.swift */; };
+		9880E7111C09EE2900ED5293 /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9880E70D1C09EE2800ED5293 /* FunctionType.swift */; };
 		9884E2A71B60B77400120259 /* ServiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E2A61B60B77400120259 /* ServiceKey.swift */; };
 		9884E2A81B60B77400120259 /* ServiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E2A61B60B77400120259 /* ServiceKey.swift */; };
 		9884E2AA1B60C51C00120259 /* ServiceKeySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E2A91B60C51C00120259 /* ServiceKeySpec.swift */; };
@@ -300,6 +304,7 @@
 		986A58391B6D031700FE710F /* Animals.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Animals.storyboard; sourceTree = "<group>"; };
 		9878C6371B65C9E000CBEFEF /* AnimalType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimalType.swift; sourceTree = "<group>"; };
 		9878C63B1B65CA8700CBEFEF /* PersonType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonType.swift; sourceTree = "<group>"; };
+		9880E70D1C09EE2800ED5293 /* FunctionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionType.swift; sourceTree = "<group>"; };
 		9884E2A61B60B77400120259 /* ServiceKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceKey.swift; sourceTree = "<group>"; };
 		9884E2A91B60C51C00120259 /* ServiceKeySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceKeySpec.swift; sourceTree = "<group>"; };
 		988EEDAE1BCA082900E935F7 /* Storyboard2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard2.storyboard; sourceTree = "<group>"; };
@@ -480,6 +485,7 @@
 				98B012BA1B82D6A400053A32 /* Container.Arguments.erb */,
 				984774EF1C02F25D0092A757 /* SynchronizedResolver.swift */,
 				984774F41C02F4EA0092A757 /* SynchronizedResolver.Arguments.erb */,
+				9880E70D1C09EE2800ED5293 /* FunctionType.swift */,
 				9884E2A61B60B77400120259 /* ServiceKey.swift */,
 				985BAFA81B625E0F0055F998 /* ServiceEntry.swift */,
 				981577F31B676BF700BF686B /* ResolutionPool.swift */,
@@ -1032,6 +1038,7 @@
 				981577F51B676BF700BF686B /* ResolutionPool.swift in Sources */,
 				98E9469A1BC92CD600FA6B37 /* NSStoryboard+Swizzling.swift in Sources */,
 				989377C71BCBA125008F4B0F /* SwinjectStoryboardType.swift in Sources */,
+				9880E70F1C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				981650351B6D0C0E00BC4222 /* _SwinjectStoryboardBase.m in Sources */,
 				98B012C01B82F68E00053A32 /* Resolvable.swift in Sources */,
 				986A58281B6CCC9600FE710F /* Container+Typealias.swift in Sources */,
@@ -1078,6 +1085,7 @@
 			files = (
 				986A582F1B6CFA3400FE710F /* RegistrationNameAssociatable.swift in Sources */,
 				983B98311C06ECB2006A23D4 /* SpinLock.swift in Sources */,
+				9880E70E1C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				985BAFA91B625E0F0055F998 /* ServiceEntry.swift in Sources */,
 				98D06D3F1B6BA7B60081AFE0 /* UIViewController+Swinject.swift in Sources */,
 				986A58261B6CCB2800FE710F /* Container+Typealias.swift in Sources */,
@@ -1127,6 +1135,7 @@
 			files = (
 				983B98331C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				985011231BBE7E8900A2CCFC /* RegistrationNameAssociatable.swift in Sources */,
+				9880E7101C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				985011221BBE7E8900A2CCFC /* ObjectScope.swift in Sources */,
 				985011251BBE7E8900A2CCFC /* Resolvable.swift in Sources */,
 				9850111E1BBE7E8900A2CCFC /* Container.swift in Sources */,
@@ -1148,6 +1157,7 @@
 			files = (
 				98689C9E1BBFC7EB0005C6D3 /* RegistrationNameAssociatable.swift in Sources */,
 				983B98341C06ECB2006A23D4 /* SpinLock.swift in Sources */,
+				9880E7111C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				98689C9D1BBFC7EB0005C6D3 /* ObjectScope.swift in Sources */,
 				98689CA11BBFC7F20005C6D3 /* Container+Typealias.swift in Sources */,
 				98689CA21BBFC7F20005C6D3 /* SwinjectStoryboard.swift in Sources */,

--- a/Swinject/Container.swift
+++ b/Swinject/Container.swift
@@ -23,7 +23,7 @@ import Foundation
 ///
 /// where `A` and `X` are protocols, `B` is a type conforming `A`, and `Y` is a type conforming `X` and depending on `A`.
 public final class Container {
-    private var services = [ServiceKey: ServiceEntryBase]()
+    private var services = [ServiceKey: ServiceEntryType]()
     private let parent: Container?
     private var resolutionPool = ResolutionPool()
     internal let lock: SpinLock // Used by SynchronizedResolver.

--- a/Swinject/FunctionType.swift
+++ b/Swinject/FunctionType.swift
@@ -1,0 +1,10 @@
+//
+//  FunctionType.swift
+//  Swinject
+//
+//  Created by Yoichi Tagaya on 11/28/15.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//
+
+// Type alias to expect a closure.
+internal typealias FunctionType = Any

--- a/Swinject/ServiceEntry.swift
+++ b/Swinject/ServiceEntry.swift
@@ -42,12 +42,6 @@ public final class ServiceEntry<Service>: ServiceEntryBase {
         super.init(factory: factory)
     }
 
-    // Initializer for Container.registerForStoryboard.
-    internal convenience init(serviceType: Service.Type) {
-        let emptyFactory: () -> () = { }
-        self.init(serviceType: serviceType, factory: emptyFactory)
-    }
-
     internal func copyExceptInstance() -> ServiceEntry<Service> {
         let copy = ServiceEntry(serviceType: serviceType, factory: factory)
         copy.objectScope = objectScope

--- a/Swinject/ServiceEntry.swift
+++ b/Swinject/ServiceEntry.swift
@@ -16,11 +16,11 @@ internal typealias ServiceEntryType = Any
 public final class ServiceEntry<Service>: ServiceEntryType {
     private let serviceType: Service.Type
     internal let factory: FunctionType
-    
+
     internal var objectScope = ObjectScope.Graph
     internal var initCompleted: FunctionType?
     internal var instance: Any?
-    
+
     internal init(serviceType: Service.Type, factory: FunctionType) {
         self.serviceType = serviceType
         self.factory = factory
@@ -42,7 +42,7 @@ public final class ServiceEntry<Service>: ServiceEntryType {
         self.objectScope = objectScope
         return self
     }
-    
+
     /// Adds the callback to setup the instance after its `init` completes.
     /// *Property or method injections* can be performed in the callback.
     /// To resolve *circular dependencies*, `initCompleted` must be used.

--- a/Swinject/ServiceEntry.swift
+++ b/Swinject/ServiceEntry.swift
@@ -8,19 +8,31 @@
 
 import Foundation
 
-/// The `ServiceEntryBase` class represents an entry of a registered service type.
-/// It is free from generics to store in a strongly typed collection.
-/// `ServiceEntry<Service>` should be actually used.
-public class ServiceEntryBase {
+// A generic-type-free protocol to be the type of values in a strongly-typed collection.
+internal typealias ServiceEntryType = Any
+
+/// The `ServiceEntry<Service>` class represents an entry of a registered service type.
+/// As a returned instance from a `register` method of a `Container`, some configurations can be added.
+public final class ServiceEntry<Service>: ServiceEntryType {
+    private let serviceType: Service.Type
     internal let factory: Any // Must be a function type.
+    
     internal var objectScope = ObjectScope.Graph
     internal var instance: Any?
     internal var initCompleted: Any? // Must be a function type.
     
-    internal init(factory: Any) {
+    internal init(serviceType: Service.Type, factory: Any) {
+        self.serviceType = serviceType
         self.factory = factory
     }
-    
+
+    internal func copyExceptInstance() -> ServiceEntry<Service> {
+        let copy = ServiceEntry(serviceType: serviceType, factory: factory)
+        copy.objectScope = objectScope
+        copy.initCompleted = initCompleted
+        return copy
+    }
+
     /// Specifies the object scope to resolve the service.
     ///
     /// - Parameter scope: The `ObjectScope` value.
@@ -29,24 +41,6 @@ public class ServiceEntryBase {
     public func inObjectScope(objectScope: ObjectScope) -> Self {
         self.objectScope = objectScope
         return self
-    }
-}
-
-/// The `ServiceEntry<Service>` class represents an entry of a registered service type.
-/// As a returned instance from a `register` method of a `Container`, some configurations can be added.
-public final class ServiceEntry<Service>: ServiceEntryBase {
-    private let serviceType: Service.Type
-    
-    internal init(serviceType: Service.Type, factory: Any) {
-        self.serviceType = serviceType
-        super.init(factory: factory)
-    }
-
-    internal func copyExceptInstance() -> ServiceEntry<Service> {
-        let copy = ServiceEntry(serviceType: serviceType, factory: factory)
-        copy.objectScope = objectScope
-        copy.initCompleted = initCompleted
-        return copy
     }
     
     /// Adds the callback to setup the instance after its `init` completes.

--- a/Swinject/ServiceEntry.swift
+++ b/Swinject/ServiceEntry.swift
@@ -15,13 +15,13 @@ internal typealias ServiceEntryType = Any
 /// As a returned instance from a `register` method of a `Container`, some configurations can be added.
 public final class ServiceEntry<Service>: ServiceEntryType {
     private let serviceType: Service.Type
-    internal let factory: Any // Must be a function type.
+    internal let factory: FunctionType
     
     internal var objectScope = ObjectScope.Graph
+    internal var initCompleted: FunctionType?
     internal var instance: Any?
-    internal var initCompleted: Any? // Must be a function type.
     
-    internal init(serviceType: Service.Type, factory: Any) {
+    internal init(serviceType: Service.Type, factory: FunctionType) {
         self.serviceType = serviceType
         self.factory = factory
     }

--- a/Swinject/ServiceKey.swift
+++ b/Swinject/ServiceKey.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 internal struct ServiceKey {
-    private let factoryType: Any.Type
+    private let factoryType: FunctionType.Type
     private let name: String?
     
-    internal init(factoryType: Any.Type, name: String? = nil) {
+    internal init(factoryType: FunctionType.Type, name: String? = nil) {
         self.factoryType = factoryType
         self.name = name
     }

--- a/SwinjectTests/ServiceEntrySpec.swift
+++ b/SwinjectTests/ServiceEntrySpec.swift
@@ -13,7 +13,7 @@ import Nimble
 class ServiceEntrySpec: QuickSpec {
     override func spec() {
         it("has ObjectScope.Graph as a default value of scope property.") {
-            let entry = ServiceEntryBase(factory: 0)
+            let entry = ServiceEntry(serviceType: Int.self, factory: { return 0 })
             expect(entry.objectScope) == ObjectScope.Graph
         }
     }


### PR DESCRIPTION
- Use `ServiceEntryType` typealias in place of `ServiceEntryBase` class to remove unnecessary inheritance of `ServiceEntry<Service>` class.
- Introduce `FunctionType` typealias of `Any` and replace `Any` that requires a function (closure) with it.