### PR TITLE
Update project settings to Xcode 7.2

### DIFF
--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -957,7 +957,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Swinject Contributors";
 				TargetAttributes = {
 					981899BB1B5FE63F00C702D0 = {

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Updated the project settings to Xcode 7.2. Modified fields were `LastUpgradeCheck` and `LastUpgradeVersion` only, and no actual (effective) changes were made.

Since Travis still does not support the official release of Xcode 7.2, .travis.yml was not updated yet.