### PR TITLE
Container with parent assembly

### DIFF
--- a/Swinject/Assembler.swift
+++ b/Swinject/Assembler.swift
@@ -26,6 +26,14 @@ public class Assembler {
         self.container = container!
     }
     
+    /// Will create an empty `Assembler`
+    ///
+    /// - parameter parentAssembler: the baseline assembler
+    ///
+    public init(parentAssembler: Assembler) {
+        container = Container(parent: parentAssembler.container)
+    }
+    
     /// Will create a new `Assembler` with the given `AssemblyType` instances to build a `Container`
     ///
     /// - parameter assemblies:         the list of assemblies to build the container from
@@ -34,6 +42,22 @@ public class Assembler {
     ///
     public init(assemblies: [AssemblyType], propertyLoaders: [PropertyLoaderType]? = nil, container: Container? = Container()) throws {
         self.container = container!
+        if let propertyLoaders = propertyLoaders {
+            for propertyLoader in propertyLoaders {
+                try self.container.applyPropertyLoader(propertyLoader)
+            }
+        }
+        runAssemblies(assemblies)
+    }
+    
+    /// Will create a new `Assembler` with the given `AssemblyType` instances to build a `Container`
+    ///
+    /// - parameter assemblies:         the list of assemblies to build the container from
+    /// - parameter parentAssembler:    the baseline assembler
+    /// - parameter propertyLoaders:    a list of property loaders to apply to the container
+    ///
+    public init(assemblies: [AssemblyType], parentAssembler: Assembler, propertyLoaders: [PropertyLoaderType]? = nil) throws {
+        container = Container(parent: parentAssembler.container)
         if let propertyLoaders = propertyLoaders {
             for propertyLoader in propertyLoaders {
                 try self.container.applyPropertyLoader(propertyLoader)

--- a/SwinjectTests/AssemblerSpec.swift
+++ b/SwinjectTests/AssemblerSpec.swift
@@ -248,5 +248,40 @@ class AssemblerSpec: QuickSpec {
                 expect(cat!.name) == "first"
             }
         }
+        
+        describe("Child Assembler") {
+            it("can be empty") {
+                let assembler = try! Assembler(assemblies: [
+                    AnimalAssembly()
+                ])
+                
+                let childAssembler = Assembler(parentAssembler: assembler)
+                
+                let cat = assembler.resolver.resolve(AnimalType.self)
+                expect(cat).toNot(beNil())
+                
+                let sushi = assembler.resolver.resolve(FoodType.self)
+                expect(sushi).to(beNil())
+                
+                let childCat = childAssembler.resolver.resolve(AnimalType.self)
+                expect(childCat).toNot(beNil())
+                
+                let childSushi = childAssembler.resolver.resolve(FoodType.self)
+                expect(childSushi).to(beNil())
+            }
+            
+            it("can't give entities to parent") {
+                let assembler = Assembler()
+                let childAssembler = try! Assembler(assemblies: [
+                    AnimalAssembly()
+                ], parentAssembler: assembler)
+                
+                let cat = assembler.resolver.resolve(AnimalType.self)
+                expect(cat).to(beNil())
+                
+                let childCat = childAssembler.resolver.resolve(AnimalType.self)
+                expect(childCat).toNot(beNil())
+            }
+        }
     }
 }


### PR DESCRIPTION
## Container with parent assembly
This PR contains changes & tests for creating container with parent assembly.

### Why?
Assume you have `ApiManager`, `ViewController1` and `ViewController2` in TabBar application. Both controllers asks API for some data. To implement this scheme we can create the following container hierarchy:
- `RootContainer` (where ApiManager lives)
  - `Controller1Container` (all specific dependencies for VC1)
  - `Controller2Container` (all specific dependencies for VC2)

Later you decide to make a new feature: background upload (or tracking user location, etc). You have bunch of classes, that are responsible for that. Now you have two options:
  1. Create `BackgroundUploadContainer` and put all dependencies there
  2. Put all code to `RootContainer`

Both of them are not so good and shiny: 
  1. You can't add it to current hierarchy, as you might want to add new "service" and it will lead you to multiple inheritance
  2. Your `RootContainer` will be soon a 10-screen-height file with lots of dependencies

### Solutions?
We can have a `RootAssembly` = `RootContainer` + `BackgroundUploadContainer`. But with that solution it's impossible to have `Controller1Container` knowing about both of them (no container constructor accepts `Assembler`).

I propose to add such a constructor.