### PR TITLE
Fixed assembler constructor: parent assembler is optional

### DIFF
--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -30,8 +30,8 @@ public class Assembler {
     ///
     /// - parameter parentAssembler: the baseline assembler
     ///
-    public init(parentAssembler: Assembler) {
-        container = Container(parent: parentAssembler.container)
+    public init(parentAssembler: Assembler?) {
+        container = Container(parent: parentAssembler?.container)
     }
     
     /// Will create a new `Assembler` with the given `AssemblyType` instances to build a `Container`
@@ -56,8 +56,8 @@ public class Assembler {
     /// - parameter parentAssembler:    the baseline assembler
     /// - parameter propertyLoaders:    a list of property loaders to apply to the container
     ///
-    public init(assemblies: [AssemblyType], parentAssembler: Assembler, propertyLoaders: [PropertyLoaderType]? = nil) throws {
-        container = Container(parent: parentAssembler.container)
+    public init(assemblies: [AssemblyType], parentAssembler: Assembler?, propertyLoaders: [PropertyLoaderType]? = nil) throws {
+        container = Container(parent: parentAssembler?.container)
         if let propertyLoaders = propertyLoaders {
             for propertyLoader in propertyLoaders {
                 try self.container.applyPropertyLoader(propertyLoader)

--- a/Tests/AssemblerSpec.swift
+++ b/Tests/AssemblerSpec.swift
@@ -27,6 +27,25 @@ class AssemblerSpec: QuickSpec {
                 expect(sushi).to(beNil())
             }
             
+            it("can assembly a container with nil parent") {
+                let assembler = Assembler(parentAssembler: nil)
+                
+                let sushi = assembler.resolver.resolve(FoodType.self)
+                expect(sushi).to(beNil())
+            }
+            
+            it("can assembly a container with nil parent and assemblies") {
+                let assembler = try! Assembler(assemblies: [
+                    AnimalAssembly()
+                    ], parentAssembler : nil)
+                let cat = assembler.resolver.resolve(AnimalType.self)
+                expect(cat).toNot(beNil())
+                expect(cat!.name) == "Whiskers"
+                
+                let sushi = assembler.resolver.resolve(FoodType.self)
+                expect(sushi).to(beNil())
+            }
+            
             it("can assembly a multiple container") {
                 let assembler = try! Assembler(assemblies: [
                     AnimalAssembly(),


### PR DESCRIPTION
Consider code:

```
// MyFile.swift

func getMyAssembler(parentAssembler: Assembler?) -> Assembler {
   if let parent = parentAssembler {
        return Assembler(parentAssembler: parent)
   } else {
        return Assembler() 
   }
}
```

The goal of PR is to simplify this function to: 
```
func getMyAssembler(parentAssembler: Assembler?) -> Assembler {
     return Assembler(parentAssembler: parent)
}
```

This is the PR I've mentioned here: https://github.com/Nikita2k/SwiftViper/issues/1