### PR TITLE
Grammer and comprehension edits

### DIFF
--- a/Documentation/Assembler.md
+++ b/Documentation/Assembler.md
@@ -1,16 +1,19 @@
 # Modularizing Service Registration
+
 This feature provides your implementation the ability to group related service definitions together
 in an `AssemblyType`. This allows your application to:
 
-   - keep things organized by keeping like services in 1 place
-   - provided a shared `Container`
-   - allows registering different assembly configurations which is useful for swapping out mock implementations
-   - can be "load aware" when the container is fully configured
+   - Keep things organized by keeping like services in one place.
+   - Provide a shared `Container`.
+   - Allow registering different assembly configurations, which is useful for swapping in mock implementations.
+   - To be notified when the container is fully configured.
 
-This feature is an opinionated way to how your can register services in your `Container`. There are
-parts to this feature:
+This feature is an opinionated way to how your can register services in your `Container` and using it is not required.
+
+There are several parts to this feature.
 
 ## AssemblyType
+
 The `AssemblyType` is a protocol that is provided a shared `Container` where service definitions
 can be registered. The shared `Container` will contain **all** service definitions from every
 `AssemblyType` registered to the `Assembler`. Let's look at an example:
@@ -45,6 +48,7 @@ doesn't care where the `FooServiceType` and `BarServiceType` are registered, it 
 be registered else where.
 
 ### Load aware
+
 The `AssemblyType` allows the assembly to be aware when the container has been fully loaded
 by the `Assembler`.
 
@@ -107,8 +111,9 @@ class LoggerAssembly: AssemblyType {
 ```
 
 ## Assembler
+
 The `Assembler` is responsible for managing the `AssemblyType` instances and the `Container`. Using
-the `Assembler` the `Container` is only exposed to assemblies registered with the assembler and
+the `Assembler`, the `Container` is only exposed to assemblies registered with the assembler and
 only provides your application access via the `ResolverType` protocol which limits registration
 access strictly to the assemblies.
 
@@ -149,6 +154,7 @@ assembler.applyPropertyLoader(
 ```
 
 ## IMPORTANT:
+
  - You **MUST** hold a strong reference to the `Assembler` otherwise the `Container`
    will be deallocated along with your assembler
 

--- a/Documentation/CircularDependencies.md
+++ b/Documentation/CircularDependencies.md
@@ -1,10 +1,10 @@
 # Circular Dependencies
 
-Circular Dependencies are dependencies of instances that depend on each other. To define Circular Dependencies by Swinject, either of the dependencies must be injected through the property.
+_Circular dependencies_ are dependencies of instances that depend on each other. To define circular dependencies in Swinject, one or other of the dependencies must be injected through a property.
 
 ## Initializer/Property Dependencies
 
-Assume that you have `Parent` and `Child` classes depending on each other. `Parent` depends on `ChildType` through its initializer, and `Child` on `ParentType` through its property. The back-reference from `Child` to `ParentType` is a weak property to avoid memory leak.
+Assume that you have `Parent` and `Child` classes depending on each other. `Parent` depends on `ChildType` through its initializer, and `Child` on `ParentType` through a property. The back-reference from `Child` to `ParentType` is a weak property to avoid a memory leak.
 
 ```swift
 protocol ParentType: AnyObject { }
@@ -37,11 +37,11 @@ container.register(ChildType.self) { _ in Child() }
     }
 ```
 
-Here the injection to the `parent` property of `Child` must be specified in the `initCompleted` callback to get rid of infinite recursive calls.
+Here the injection to the `parent` property of `Child` must be specified in the `initCompleted` callback to get avoid infinite recursion.
 
 ## Property/Property Dependencies
 
-Similarly, assume that you have the following classes depending through each property.
+Similarly, assume that you have the following classes depending on each other, each via a property.
 
 ```swift
 protocol ParentType: AnyObject { }
@@ -56,7 +56,7 @@ class Child: ChildType {
 }
 ```
 
-The Circular Dependencies are defined as below.
+The circular dependencies are defined as below:
 
 ```swift
 let container = Container()
@@ -72,11 +72,11 @@ container.register(ChildType.self) { _ in Child() }
     }
 ```
 
-Here the both or either of the depending properties must be specified in the `initCompleted` callback to get rid of infinite recursive calls.
+Here both or either of the depending properties must be specified in the `initCompleted` callback to avoid infinite recursivion.
 
 ## Initializer/Initializer Dependencies
 
-Not supported. This type of dependencies causes infinite recursive calls.
+_Not supported._ This type of dependency causes infinite recursion.
 
 _[Next page: Object Scopes](ObjectScopes.md)_
 

--- a/Documentation/ContainerHierarchy.md
+++ b/Documentation/ContainerHierarchy.md
@@ -1,6 +1,6 @@
 # Container Hierarchy
 
-A container hierarchy is a relationship of containers to share registrations of dependency injections. Service types registered to a parent container can be resolved in its child containers too. Use `init(parent: Container)` to instantiate a child container with its parent passed.
+A container hierarchy is a tree of containers for the purposes of sharing the registrations of dependency injections. Service types registered to a parent container can be resolved in its child containers too. Use `init(parent: Container)` to instantiate a child container while specifying its parent container:
 
 ```swift
 let parentContainer = Container()
@@ -11,7 +11,7 @@ let cat = childContainer.resolve(AnimalType.self)
 print(cat != nil) // prints "true"
 ```
 
-In contrast, service types registered to a child container are not resolved in its parent container.
+In contrast, service types registered to a child container are _not_ resolved in its parent container:
 
 ```swift
 let parentContainer = Container()

--- a/Documentation/DIContainer.md
+++ b/Documentation/DIContainer.md
@@ -1,18 +1,21 @@
 # DI Container
 
-Dependency Injection (DI) Container manages dependencies of your system. First you register the way how the dependencies or actual types should be resolved. Then you use the DI container to get instances whose dependencies or actual types are resolved by the DI container. In Swinject, `Container` class represents the DI container.
+[Dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) (DI) is a software design pattern that uses [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control) (IoC) for resolving dependencies. A DI _container_ manages the type dependencies of your system. First, you register the  types that should be resolved, with their dependencies. Then you use the DI container to get instances of those types whose dependencies are then automatically resolved by the DI container. In Swinject, the `Container` class represents the DI container.
 
-In the field of Dependency Injection or Inversion of Control, different terms are used or terms are used differently. Swinject uses the following terms.
+Unfortunately, implementations of dependency injection often use slightly different terminology, which if not explained clearly in advance can cause confusion. In Swinject we define the following terms:
 
-* **Service**: Protocol defining an interface for a dependent type.
-* **Component**: Actual type implementing a service.
-* **Factory**: Function or closure instantiating a component type.
+* **Service**: A protocol defining an interface for a dependent type.
+* **Component**: An actual type implementing a service.
+* **Factory**: A function or closure instantiating a component.
+* **Container**: A collection of component instances.
 
-## Registration to DI Container
+Note the terms _service instance_ and _component instance_ mean the same thing, and are used interchangeably.
 
-A service resolved to a component is registered with `register` method of a component that takes the service type and a factory of the component. If the component depends on another service, `resolve` method can be used in the factory to inject the dependency. The actual type of the dependency will be resolved later when the component instance is created.
+## Registration in a DI Container
 
-Here is an example of the registration.
+A service and its corresponding component are registered with the `register` method of the container.  The method takes the service type for the component and a factory method. If the component depends on another service, the factory method can call `resolve` on the passed in resolver objection to "inject" the dependency. The actual underlying type of the dependency will determined later when the component instance is created.
+
+Here is an example of service registration.
 
 ```swift
 let container = Container()
@@ -51,7 +54,7 @@ class PetOwner: PersonType {
 }
 ```
 
-After you register the dependencies, you can get service instances from the container by calling `resolve` method. It returns resolved components as the specified service (protocol) types.
+After you register the components, you can get service instances from the container by calling the `resolve` method. It returns resolved components with the specified service (protocol) types.
 
 ```swift
 let animal = container.resolve(AnimalType.self)!
@@ -66,9 +69,9 @@ print(pet.name) // prints "Mimi"
 print(pet is Cat) // prints "true"
 ```
 
-Here the instances resolved by `resolve` method are unwrapped with `!` because it returns nil if no registration for the specified service type is found.
+Here the instances resolved by the `resolve` method are unwrapped with `!` because it returns `nil` if no registration for the specified service type is found.
 
-## Named Registration to DI Container
+## Named Registration in a DI Container
 
 If you would like to register two or more components for a service type, you can name the registrations to differentiate.
 
@@ -102,9 +105,9 @@ class Dog: AnimalType {
 }
 ```
 
-## Registration with Arguments to DI Container
+## Registration with Arguments in a DI Container
 
-A factory closure to register a service can take arguments that are passed when the service is resolved. When you register the service, the arguments can be specified after the `Resolvable` parameter (in the following example, it is unused as `_`).
+The factory closure passed to the `register` method can take arguments that are passed when the service is resolved. When you register the service, the arguments can be specified after the `Resolvable` parameter. Note that if the resolver is not use it can be given as `_` as in the following example (this is practice in  Swift):
 
 ```swift
 container.register(AnimalType.self) { _, name in
@@ -153,17 +156,17 @@ class Horse: AnimalType {
 
 ## Registration Keys
 
-A registration is stored in a container with an internally created key. The container tries to resolve a service that is registered with the key.
+A registration of the component for a given service is stored in a container with an internally created key. The container uses the key when trying to resolve a service dependency.
 
 The key consists of:
 
-* Type of the service
-* Name of the registration
-* Number and types of the arguments
+* The type of the service
+* The name of the registration
+* The number and types of the arguments
 
-If a registration matches an existing registration with all the parts of the key, the existing registration is overwritten with the new registration.
+If a registration matches an existing registration with all the parts of the key, the existing registration is _overwritten_ with the new registration.
 
-For example the following registrations can co-exist in a container because the service types are different.
+For example, the following registrations can co-exist in a container because the service _types_ are different:
 
 ```swift
 container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
@@ -172,21 +175,21 @@ container.register(PersonType.self) { r in
 }
 ```
 
-The following registrations can co-exist in a container because the registration names are different.
+The following registrations can co-exist in a container because the registration _names_ are different:
 
 ```swift
 container.register(AnimalType.self, name: "cat") { _ in Cat(name: "Mimi") }
 container.register(AnimalType.self, name: "dog") { _ in Dog(name: "Hachi") }
 ```
 
-The following registrations can co-exist in a container because the numbers of arguments are different. The first registration has no arguments, and the second has an argument.
+The following registrations can co-exist in a container because the _numbers of arguments_ are different. The first registration has no arguments, and the second has an argument:
 
 ```swift
 container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
 container.register(AnimalType.self) { _, name in Cat(name: name) }
 ```
 
-The following registrations can co-exist in a container because the types of arguments are different. The first registration has `String` and `Bool` types. The second registration has `Bool` and `String` types in the order.
+The following registrations can co-exist in a container because the _types of the arguments_ are different. The first registration has `String` and `Bool` types. The second registration has `Bool` and `String` types in the order:
 
 ```swift
 container.register(AnimalType.self) { _, name, running in

--- a/Documentation/InjectionPatterns.md
+++ b/Documentation/InjectionPatterns.md
@@ -2,9 +2,9 @@
 
 ## Initializer Injection
 
-Initializer Injection is a pattern to pass dependencies to a dependent instance by its initializer. Initializer Injection is appropriate if the dependent instance cannot work without the dependencies.
+_Initializer injection_ is a pattern for passing  dependencies to a dependent instance by its initializers. Initializer injection is appropriate if the dependent instance cannot work without the dependencies.
 
-The following code defines Initializer Injection to `PetOwner`, which depends on `AnimalType`.
+The following code defines initializer injection to `PetOwner`, which depends on `AnimalType`:
 
 ```swift
 let container = Container()
@@ -40,13 +40,13 @@ class PetOwner: PersonType {
 }
 ```
 
-Note that the actual type of `AnimalType` passed to the initializer of `PetOwner` is automatically resolved by Swinject when `PetOwner` instance is created.
+Note that the actual type of `AnimalType` passed to the initializer of `PetOwner` is automatically resolved by Swinject when the `PetOwner` instance is created:
 
 ## Property Injection
 
-Property Injection is a pattern to pass a dependency to a dependent instance by its setter property. Property Injection is appropriate if the dependency is optional to the dependent instance.
+_Property injection_ is a pattern to pass a dependency to a dependent instance via a setter property. Property injection is appropriate if the dependency is optional to the dependent instance.
 
-The following code defines Property Injection to `PetOwner2`.
+The following code defines property injection to `PetOwner2`:
 
 ```swift
 let container = Container()
@@ -68,7 +68,7 @@ class PetOwner2: PersonType {
 }
 ```
 
-Or you can use <a name="initialization-callback">`initCompleted` callback</a> instead of defining the injection in the registration closure.
+Or, you can use <a name="initialization-callback">`initCompleted` callback</a> instead of defining the injection in the registration closure:
 
 ```swift
 let container = Container()
@@ -82,9 +82,9 @@ container.register(PersonType.self) { _ in PetOwner2() }
 
 ## Method Injection
 
-Method Injection is a similar pattern to Property Injection, but it uses a method to pass dependencies to a dependent instance.
+_Method injection_ is a similar pattern to _property injection_, but it uses a method to pass dependencies to a dependent instance.
 
-The following code defines Property Injection to `PetOwner3`.
+The following code defines Property Injection to `PetOwner3`:
 
 ```swift
 let container = Container()
@@ -110,7 +110,7 @@ class PetOwner3: PersonType {
 }
 ```
 
-Or you can use `initCompleted` callback instead of defining the injection in the registration closure.
+Or, you can use `initCompleted` callback instead of defining the injection in the registration closure:
 
 ```swift
 let container = Container()

--- a/Documentation/Misc.md
+++ b/Documentation/Misc.md
@@ -37,7 +37,7 @@ print(turtle1.name) // prints "Ninja"
 
 ## Self-registration (Self-binding)
 
-In Swinject or other DI frameworks, a service type can be not only a protocol but also a concrete or abstract classes. A special case is that the service type and component type are identical. The case is called Self-registration or Self-binding. Here is an example of self-binding with Swinject.
+In Swinject or other DI frameworks, a service type can not only be a protocol but also a concrete or abstract classes. A special case is when the service type and component type are identical. This case is called _self-registration_ or _self-binding_. Here is an example of self-binding with Swinject:
 
 ```swift
 let container = Container()
@@ -47,7 +47,7 @@ container.register(PetOwner.self) { r in
 }
 ```
 
-Then a `PetOnwer` service is resolved as itself.
+Then a `PetOwner` service is resolved as itself:
 
 ```swift
 let owner = container.resolve(PetOwner.self)!

--- a/Documentation/ObjectScopes.md
+++ b/Documentation/ObjectScopes.md
@@ -1,6 +1,6 @@
 # Object Scopes
 
-Object scope is a configuration how an instance provided by a DI container is shared in the system. It is represented by enum `ObjectScope` in Swinject.
+Object scope is a configuration option to determine how an instance provided by a DI container is shared in the system. It is represented by enum `ObjectScope` in Swinject.
 
 The object scope is specified with `inObjectScope` method when you register a pair of a service type and component factory. For example:
 
@@ -9,25 +9,25 @@ container.register(AnimalType.self) { _ in Cat() }
     .inObjectScope(.Container)
 ```
 
-The object scope is ignored if the factory closure returns a value type because its instance is never shared as the specification of Swift.
+The object scope is ignored if the factory closure returns a value type because its instance is never shared per the Swift specification.
 
 ## None (aka Transient)
 
 If `ObjectScope.None` is specified, an instance provided by a container is not shared. In other words, the container always creates a new instance when the type is resolved.
 
-This scope is also known as Transient in other DI frameworks.
+This scope is also known as _Transient_ in other DI frameworks.
 
 ## Graph (the default scope)
 
-In `ObjectScope.Graph`, an instance is always created, like in `ObjectScope.None`, if you directly call `resolve` method of a container, but instances resolved in factory closures are shared during the resolution of the root instance to construct an object graph.
+With `ObjectScope.Graph`, an instance is always created, as in `ObjectScope.None`, if you directly call `resolve` method of a container, but instances resolved in factory closures are shared during the resolution of the root instance to construct the object graph.
 
 This scope must be specified, or `inObjectScope` must not be called if you register circular dependencies.
 
 ## Container (aka Singleton)
 
-In `ObjectScope.Container`, an instance provided by a container is shared within the container. In other words, when you resolve the type at the first time, it is created by the container invoking the factory closure. The instance is returned by the container in the succeeding resolution of the type.
+In `ObjectScope.Container`, an instance provided by a container is shared within the container. In other words, when you resolve the type for the first time, it is created by the container by invoking the factory closure. The same instance is returned by the container in any succeeding resolution of the type.
 
-This scope is also known as Singleton in other DI frameworks.
+This scope is also known as _Singleton_ in other DI frameworks.
 
 ## Hierarchy
 

--- a/Documentation/Properties.md
+++ b/Documentation/Properties.md
@@ -1,7 +1,9 @@
 # Properties
-Properties can be loaded from resources that are bundled with your application/framework.
-These properties can be used when assembling definitions in your container. There
-are 2 types of support property formats:
+
+Properties are values that can be loaded from resources that are bundled with your application/framework.
+Properties can then be used when assembling definitions in your container.
+
+There are 2 types of support property formats:
 
  - JSON (`JsonPropertyLoader`)
  - Plist (`PlistPropertyLoader`)
@@ -41,6 +43,7 @@ try! container.applyPropertyLoader(loader)
 ```
 
 Now you can inject properties into definitions registered into the container.
+
 Consider the following definition:
 
 ```swift

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Swinject is a lightweight dependency injection framework for Swift apps. It helps your app split into loosely-coupled components, which can be maintained and tested more easily. Swinject <a name="pure-swift-type-support">supports pure Swift types</a>, and is powered by the Swift generic type system and first class functions to simply define dependencies of types in your app.
+Swinject is a lightweight dependency injection framework for Swift apps. It allows you to split your app into loosely-coupled components, which can then be maintained and tested more easily. Swinject <a name="pure-swift-type-support">supports pure Swift types</a>, and is powered by the Swift generic type system and [first class functions](https://en.wikipedia.org/wiki/First-class_function).  This makes it syntactically elegant and simple to define the object dependencies for your app.
 
 ## Table of Contents
 

--- a/Documentation/Storyboard.md
+++ b/Documentation/Storyboard.md
@@ -1,22 +1,24 @@
 # Storyboard
 
-Swinject supports dependency injection to view controllers instantiated by `SwinjectStoryboard`, which inherits `UIStoryboard` (or `NSStoryboard` in case of OS X). To register dependencies of a view controller, use `registerForStoryboard` method. In the same way as a registration of a service type, a view controller can be registered with or without a name.
+Swinject supports automatic dependency injection to view controllers instantiated by `SwinjectStoryboard`. This class inherits `UIStoryboard` (or `NSStoryboard` in case of OS X). To register dependencies of a view controller, use `registerForStoryboard` method. In the same way as a registration of a service type, a view controller can be registered with or without a name.
 
-**Note**: Do **NOT** explicitly resolve the view controllers registered by `registerForStoryboard` method. The view controllers are intended to be resolved by `SwinjectStoryboard` implicitly.
+**NOTE**: Do NOT explicitly resolve the view controllers registered by `registerForStoryboard` method. The view controllers are intended to be resolved by `SwinjectStoryboard` implicitly.
 
 ## Registration
 
 ### Registration without Name
 
-Here is an example to simply register a dependency of a view controller without a registration name.
+Here is a simple example to register a dependency of a view controller without a registration name:
 
-    let container = Container()
-    container.registerForStoryboard(AnimalViewController.self) { r, c in
-        c.animal = r.resolve(AnimalType.self)
-    }
-    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+```swift
+let container = Container()
+container.registerForStoryboard(AnimalViewController.self) { r, c in
+    c.animal = r.resolve(AnimalType.self)
+}
+container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+```
 
-Then create an instance of `SwinjectStoryboard` with the container specified. If the container is not specified, `SwinjectStoryboard.defaultContainer` is used instead. `instantiateViewControllerWithIdentifier` method creates an instance of the view controller with its dependencies injected:
+Next, we create an instance of `SwinjectStoryboard` with the container specified. If the container is not specified, `SwinjectStoryboard.defaultContainer` is used instead. `instantiateViewControllerWithIdentifier` method creates an instance of the view controller with its dependencies injected:
 
 ```swift
 let sb = SwinjectStoryboard.create(
@@ -57,7 +59,7 @@ and the storyboard named `Animals.storyboard` has `AnimalViewController` with st
 
 ### Registration with Name
 
-If a storyboard has more than a view controller with the same type, dependencies should be registered with registration names.
+If a storyboard has more than one view controller with the same type, dependencies should be registered with registration names.
 
 ```swift
 let container = Container()
@@ -75,7 +77,7 @@ container.register(AnimalType.self, name: "hachi") {
 }
 ```
 
-Then view controllers are instantiated with storyboard IDs similarly to the case without registration names.
+Then view controllers are instantiated with storyboard IDs similarly to the case without registration names:
 
 ```swift
 let sb = SwinjectStoryboard.create(
@@ -154,7 +156,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 ```
 
-Notice that you should delete `Main storyboard file base name` item (or `UIMainStoryboardFile` item if you are displaying raw keys/values) in `Info.plist` of your app.
+Notice that you should delete the `Main storyboard file base name` item (or `UIMainStoryboardFile` item if you are displaying raw keys/values) in `Info.plist` of your app.
 
 ## Storyboard References
 

--- a/Documentation/ThreadSafety.md
+++ b/Documentation/ThreadSafety.md
@@ -1,6 +1,6 @@
 # Thread Safety
 
-Swinject is designed to be used in concurrent applications. `Container` is not thread safe, but its `synchronize` method returns a thread safe view to the container as `Resolvable` type.
+Swinject is designed to be used in concurrent applications. `Container` itself is not thread safe, but its `synchronize` method returns a thread safe view to the container as `Resolvable` type.
 
 ```swift
 let container = Container()


### PR DESCRIPTION
The documentation for Swinject is great, and one of it's great
strengths.  I would like to see the use of the library continue to
increase. Hence, this commit

- Fixes a bunch of minor grammar mistakes in the text
- Rewrites a few phrases to aid comprehension
- Fixes some Markdown formatting errors