### PR TITLE
Fix warnings on selectors

### DIFF
--- a/Sources/SwinjectStoryboard/Storyboard+Swizzling.swift
+++ b/Sources/SwinjectStoryboard/Storyboard+Swizzling.swift
@@ -31,9 +31,8 @@ extension Storyboard {
             static var token: dispatch_once_t = 0
         }
         dispatch_once(&Static.token) {
-            // Do not use #selector for now to support Xcode 7.2 (Swift 2.1)
-            let original = class_getClassMethod(Storyboard.self, Selector("storyboardWithName:bundle:"))
-            let swizzled = class_getClassMethod(Storyboard.self, Selector("swinject_storyboardWithName:bundle:"))
+            let original = class_getClassMethod(Storyboard.self, #selector(Storyboard.init(name:bundle:)))
+            let swizzled = class_getClassMethod(Storyboard.self, #selector(Storyboard.swinject_storyboardWithName(_:bundle:)))
             method_exchangeImplementations(original, swizzled)
         }
     }

--- a/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
@@ -38,9 +38,10 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
             static var token: dispatch_once_t = 0
         }
         dispatch_once(&Static.token) {
-            // Do not use #selector for now to support Xcode 7.2 (Swift 2.1)
-            if SwinjectStoryboard.respondsToSelector(Selector("setup")) {
-                SwinjectStoryboard.performSelector(Selector("setup"))
+            // Use a string parameter for the selector name to avoid warnings on Selector().
+            let setupMethodName = "setup"
+            if SwinjectStoryboard.respondsToSelector(Selector(setupMethodName)) {
+                SwinjectStoryboard.performSelector(Selector(setupMethodName))
             }
         }
     }


### PR DESCRIPTION
Fixed warnings for selectors on Swift 2.2 or later recommending to use #selector (Issue #77).