### PR TITLE
Fix test failure caused by string representation of multiple services

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -197,7 +197,7 @@ extension Container: ResolverType {
 extension Container: CustomStringConvertible {
     public var description: String {
         return "["
-            + services.map { "\n    { \($1.describeWithKey($0)) }" }.joinWithSeparator(",")
+            + services.map { "\n    { \($1.describeWithKey($0)) }" }.sort().joinWithSeparator(",")
         + "\n]"
     }
 }


### PR DESCRIPTION
Sort the string representations of services to get stable order results because services are stored in a dictionary.

This PR fixes CI failure on PR #90.