### PR TITLE
Fix warnings for selector usages preparing Swift 3 specification

### DIFF
--- a/Sources/SwinjectStoryboard/Storyboard+Swizzling.swift
+++ b/Sources/SwinjectStoryboard/Storyboard+Swizzling.swift
@@ -32,8 +32,10 @@ extension Storyboard {
         }
         dispatch_once(&Static.token) {
             // Do not use #selector for now to support Xcode 7.2 (Swift 2.1)
-            let original = class_getClassMethod(Storyboard.self, Selector("storyboardWithName:bundle:"))
-            let swizzled = class_getClassMethod(Storyboard.self, Selector("swinject_storyboardWithName:bundle:"))
+            let originalName = "storyboardWithName:bundle:"
+            let swizzledName = "swinject_storyboardWithName:bundle:"
+            let original = class_getClassMethod(Storyboard.self, Selector(originalName))
+            let swizzled = class_getClassMethod(Storyboard.self, Selector(swizzledName))
             method_exchangeImplementations(original, swizzled)
         }
     }

--- a/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
@@ -38,9 +38,9 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
             static var token: dispatch_once_t = 0
         }
         dispatch_once(&Static.token) {
-            // Do not use #selector for now to support Xcode 7.2 (Swift 2.1)
-            if SwinjectStoryboard.respondsToSelector(Selector("setup")) {
-                SwinjectStoryboard.performSelector(Selector("setup"))
+            let setupMethodName = "setup"
+            if SwinjectStoryboard.respondsToSelector(Selector(setupMethodName)) {
+                SwinjectStoryboard.performSelector(Selector(setupMethodName))
             }
         }
     }


### PR DESCRIPTION
Fixes #77.

To avoid the warning, method name parameters are defined and passed to `Selector()` initializer.