### PR TITLE
Replace respondsToSelector call with optional chaining.

### DIFF
--- a/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard/SwinjectStoryboard.swift
@@ -38,10 +38,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
             static var token: dispatch_once_t = 0
         }
         dispatch_once(&Static.token) {
-            let setupMethodName = "setup"
-            if SwinjectStoryboard.respondsToSelector(Selector(setupMethodName)) {
-                SwinjectStoryboard.performSelector(Selector(setupMethodName))
-            }
+            (SwinjectStoryboard.self as SwinjectStoryboardType.Type).setup?()
         }
     }
 


### PR DESCRIPTION
Found this while removing warnings from our project that uses Swinject.