### PR TITLE
Refactor the SpinLock class to use NSLock.

### DIFF
--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 internal final class SpinLock {
-    private var lock = OS_SPINLOCK_INIT
+    private let lock = NSLock()
     
     func sync<T>(@noescape action: () -> T) -> T {
-        OSSpinLockLock(&lock)
-        defer { OSSpinLockUnlock(&lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         return action()
     }


### PR DESCRIPTION
http://engineering.postmates.com/Spinlocks-Considered-Harmful-On-iOS/

Based on this article, I've replaced `SpinLock`s usage of `OSSpinLock` with `NSLock`.

