### PR TITLE
Fix singleton creation

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -142,7 +142,7 @@ extension Container: Resolvable {
     internal func resolveImpl<Service, Factory>(name: String?, invoker: Factory -> Service) -> Service? {
         resolutionPool.incrementDepth()
         defer {
-            if(resolutionPool.currentDepth == 1) {
+            if resolutionPool.currentDepth == 1 {
                 while let pendingComplete = pendingCompletes.popLast() {
                     pendingComplete()
                 }

--- a/Sources/ResolutionPool.swift
+++ b/Sources/ResolutionPool.swift
@@ -19,6 +19,10 @@ internal struct ResolutionPool {
         set { pool[key] = newValue }
     }
     
+    internal var currentDepth: Int {
+        return depth
+    }
+    
     internal mutating func incrementDepth() {
         guard depth < ResolutionPool.maxDepth else {
             fatalError("Infinite recursive call for circular dependency has been detected. " +

--- a/Tests/Circularity.swift
+++ b/Tests/Circularity.swift
@@ -9,22 +9,32 @@
 import Foundation
 
 // MARK: Circular dependency of two objects
-internal protocol ParentType: AnyObject { }
-internal protocol ChildType: AnyObject { }
+internal protocol ParentType: AnyObject {}
+internal protocol ChildType: AnyObject {}
 
 internal class Parent: ParentType {
+    internal static var numberOfInstances: Int = 0
+    
     var child: ChildType?
     
     init() {
+        Parent.numberOfInstances += 1
     }
     
     init(child: ChildType) {
         self.child = child
+        Parent.numberOfInstances += 1
     }
 }
 
 internal class Child: ChildType {
+    internal static var numberOfInstances: Int = 0
+    
     weak var parent: ParentType?
+    
+    init() {
+        Child.numberOfInstances += 1
+    }
 }
 
 // MARK: - Circular dependency of more than two objects

--- a/Tests/ContainerSpec.Circularity.swift
+++ b/Tests/ContainerSpec.Circularity.swift
@@ -64,6 +64,30 @@ class ContainerSpec_Circularity: QuickSpec {
                 runInObjectScope(.Container)
                 runInObjectScope(.Hierarchy)
             }
+            it("resolves circular dependency while intantiating each singleton object only once.") {
+                let runInObjectScope: ObjectScope -> Void = { scope in
+                    container.removeAll()
+                    Parent.numberOfInstances = 0
+                    Child.numberOfInstances = 0
+                    container.register(ParentType.self) { r in Parent(child: r.resolve(ChildType.self)!) }
+                        .inObjectScope(scope)
+                    container.register(ChildType.self) { _ in Child() }
+                        .initCompleted { r, s in
+                            let child = s as! Child
+                            child.parent = r.resolve(ParentType.self)
+                        }
+                        .inObjectScope(scope)
+                    
+                    container.resolve(ParentType.self)
+                    container.resolve(ChildType.self)
+                    expect(Parent.numberOfInstances) == 1
+                    expect(Child.numberOfInstances) == 1
+                }
+                
+                runInObjectScope(.Container)
+                runInObjectScope(.Hierarchy)
+            }
+
         }
         describe("More than two objects") {
             it("resolves circular dependency on properties.") {


### PR DESCRIPTION
fixes #133 

Hello Yoichi,
thank you for creating Swinject!

I found that the calls to the `initCompleted` closures caused some objects to be created twice. In my case it was a ViewController which was instantiated twice during object creation.

Postponing the call to the `initComplete` methods allows the `Parent` class to be registered in the pool before the `initComplete` method of the `Child` gets executed and thus prevents the duplicate creation of `Parent`.

Please find in the PR a test case for the problem as well as a suggestion for the solution. This PR is targeted at version 1 since this is the version I'm currently using. 

Cheers,
Markus