### PR TITLE
Fix dependency cycle injection

### DIFF
--- a/Sources/DependencyAnalyzer.Arguments.erb
+++ b/Sources/DependencyAnalyzer.Arguments.erb
@@ -1,0 +1,63 @@
+//
+//  DependencyAnalyzer.Arguments.swift
+//  Swinject
+//
+//  Created by Markus Riegel on 25.09.16.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// DependencyAnalyzer.Arguments.swift is generated from DependencyAnalyzer.Arguments.erb by ERB.
+// Do NOT modify DependencyAnalyzer.Arguments.swift directly.
+// Instead, modify DependencyAnalyzer.Arguments.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+
+import Foundation
+
+// MARK: - Resolvable with Arguments
+extension DependencyAnalyzer {
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_type = i == 1 ? arg_types : "(" + arg_types + ")" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "tuple of #{i} arguments" %>
+<%   args_factory = i == 1 ? "argument" : (1..i).map { |n| "arguments.#{n-1}" }.join(", ") %>
+/// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and <%= arg_param_description %> is found in the `Container`.
+public func resolve<Service, <%= arg_types %>>(
+serviceType: Service.Type,
+<%= arg_param_name %>: <%= arg_param_type %>) -> Service?
+{
+return resolve(serviceType, name: nil, <%= arg_param_name %>: <%= arg_param_name %>)
+}
+
+/// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            <%= arg_param_description %> and name is found in the `Container`.
+public func resolve<Service, <%= arg_types %>>(
+serviceType: Service.Type,
+name: String?,
+<%= arg_param_name %>: <%= arg_param_type %>) -> Service?
+{
+typealias FactoryType = (ResolverType, <%= arg_types %>) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, <%= args_factory %>) }
+}
+
+<% end %>
+}

--- a/Sources/DependencyAnalyzer.Arguments.swift
+++ b/Sources/DependencyAnalyzer.Arguments.swift
@@ -1,0 +1,319 @@
+//
+//  DependencyAnalyzer.Arguments.swift
+//  Swinject
+//
+//  Created by Markus Riegel on 25.09.16.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// DependencyAnalyzer.Arguments.swift is generated from DependencyAnalyzer.Arguments.erb by ERB.
+// Do NOT modify DependencyAnalyzer.Arguments.swift directly.
+// Instead, modify DependencyAnalyzer.Arguments.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+
+import Foundation
+
+// MARK: - Resolvable with Arguments
+extension DependencyAnalyzer {
+/// Retrieves the instance with the specified service type and 1 argument to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - argument:   1 argument to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and 1 argument is found in the `Container`.
+public func resolve<Service, Arg1>(
+serviceType: Service.Type,
+argument: Arg1) -> Service?
+{
+return resolve(serviceType, name: nil, argument: argument)
+}
+
+/// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - argument:   1 argument to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            1 argument and name is found in the `Container`.
+public func resolve<Service, Arg1>(
+serviceType: Service.Type,
+name: String?,
+argument: Arg1) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, argument) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 2 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 2 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 3 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 3 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 4 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 4 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 5 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 5 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 6 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 6 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 7 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 7 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 8 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 8 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7) }
+}
+
+/// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type
+///            and tuple of 9 arguments is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+serviceType: Service.Type,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+{
+return resolve(serviceType, name: nil, arguments: arguments)
+}
+
+/// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
+///
+/// - Parameters:
+///   - serviceType: The service type to resolve.
+///   - name:        The registration name.
+///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+///
+/// - Returns: The resolved service type instance, or nil if no registration for the service type,
+///            tuple of 9 arguments and name is found in the `Container`.
+public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+serviceType: Service.Type,
+name: String?,
+arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+{
+typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
+return resolveImpl(name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8) }
+}
+
+}

--- a/Sources/DependencyAnalyzer.swift
+++ b/Sources/DependencyAnalyzer.swift
@@ -1,0 +1,59 @@
+//
+//  DependencyAnalyzer.swift
+//  Swinject
+//
+//  Created by Markus Riegel on 25.09.16.
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public final class DependencyAnalyzer: Resolvable {
+    
+    internal var dependencies = Set<ServiceType>()
+    
+    public init() {}
+    
+    public func resolve<Service>(
+        serviceType: Service.Type) -> Service?
+    {
+        return resolve(serviceType, name: nil)
+    }
+    
+    public func resolve<Service>(
+        serviceType: Service.Type,
+        name: String?) -> Service?
+    {
+        typealias FactoryType = ResolverType -> Service
+        return resolveImpl(name) { (factory: FactoryType) in factory(self) }
+    }
+    
+    internal func resolveImpl<Service, Factory>(name: String?, invoker: Factory -> Service) -> Service? {
+        let serviceType = Service.self
+        let serviceTypeWrapper = ServiceType(serviceType: serviceType)
+        dependencies.insert(serviceTypeWrapper)
+        return nil
+    }
+}
+
+extension DependencyAnalyzer: PropertyRetrievable {
+    public func property<Property>(name: String) -> Property? {
+        return nil
+    }
+}
+
+internal struct ServiceType: Hashable {
+    let serviceType: Any.Type
+    
+    init(serviceType: Any.Type) {
+        self.serviceType = serviceType
+    }
+    
+    var hashValue: Int {
+        return String(serviceType).hashValue
+    }
+}
+
+func ==(lhs: ServiceType, rhs: ServiceType) -> Bool {
+    return lhs.hashValue == rhs.hashValue
+}

--- a/Sources/ResolutionPool.swift
+++ b/Sources/ResolutionPool.swift
@@ -13,7 +13,6 @@ internal struct ResolutionPool {
     
     private var pool = [ServiceKey: Any]()
     private var depth: Int = 0
-    private var pendingCompletions: [()->()] = []
     
     internal subscript(key: ServiceKey) -> Any? {
         get { return pool[key] }
@@ -32,15 +31,8 @@ internal struct ResolutionPool {
         assert(depth > 0, "The depth cannot be negative.")
         
         if depth == 1 {
-            while let pendingCompletion = pendingCompletions.popLast() {
-                pendingCompletion() // Must be invoked decrementing depth counter.
-            }
             pool = [:]
         }
         depth -= 1
-    }
-    
-    internal mutating func appendPendingCompletion(completion: ()->()) {
-        pendingCompletions.append(completion)
     }
 }

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -227,6 +227,9 @@
 		98F2F7741C07E789009571E6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F2F7721C07E788009571E6 /* Box.swift */; };
 		98F2F7751C07E789009571E6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F2F7721C07E788009571E6 /* Box.swift */; };
 		98F2F7761C07E789009571E6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F2F7721C07E788009571E6 /* Box.swift */; };
+		A63FE9AD1D97EAE6002D1A8A /* DependencyAnalyzer.Arguments.erb in Resources */ = {isa = PBXBuildFile; fileRef = A63FE9AC1D97EAE6002D1A8A /* DependencyAnalyzer.Arguments.erb */; };
+		A63FE9B81D97EAF1002D1A8A /* DependencyAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63FE9B71D97EAF1002D1A8A /* DependencyAnalyzer.swift */; };
+		A63FE9BA1D97ED4D002D1A8A /* DependencyAnalyzer.Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63FE9B91D97ED4D002D1A8A /* DependencyAnalyzer.Arguments.swift */; };
 		CD5446E61D84373600B13BB4 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD5446E41D84373600B13BB4 /* RelationshipReference1.storyboard */; };
 		CD5446E71D84373600B13BB4 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD5446E41D84373600B13BB4 /* RelationshipReference1.storyboard */; };
 		CD5446E81D84373600B13BB4 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD5446E51D84373600B13BB4 /* RelationshipReference2.storyboard */; };
@@ -523,6 +526,9 @@
 		98D462771BE76D500006D45A /* ViewController1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController1.swift; sourceTree = "<group>"; };
 		98EA93BC1BCA48D000E9121D /* Storyboard1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard1.storyboard; sourceTree = "<group>"; };
 		98F2F7721C07E788009571E6 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		A63FE9AC1D97EAE6002D1A8A /* DependencyAnalyzer.Arguments.erb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DependencyAnalyzer.Arguments.erb; sourceTree = "<group>"; };
+		A63FE9B71D97EAF1002D1A8A /* DependencyAnalyzer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyAnalyzer.swift; sourceTree = "<group>"; };
+		A63FE9B91D97ED4D002D1A8A /* DependencyAnalyzer.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyAnalyzer.Arguments.swift; sourceTree = "<group>"; };
 		CD5446E41D84373600B13BB4 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
 		CD5446E51D84373600B13BB4 /* RelationshipReference2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference2.storyboard; sourceTree = "<group>"; };
 		CD5446FA1D84385800B13BB4 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
@@ -659,6 +665,8 @@
 				90B029741C18599200A6A521 /* AssemblyType.swift */,
 				981899E31B5FFE5800C702D0 /* Container.swift */,
 				98B012BA1B82D6A400053A32 /* Container.Arguments.erb */,
+				A63FE9B71D97EAF1002D1A8A /* DependencyAnalyzer.swift */,
+				A63FE9AC1D97EAE6002D1A8A /* DependencyAnalyzer.Arguments.erb */,
 				984774EF1C02F25D0092A757 /* SynchronizedResolver.swift */,
 				984774F41C02F4EA0092A757 /* SynchronizedResolver.Arguments.erb */,
 				9880E70D1C09EE2800ED5293 /* FunctionType.swift */,
@@ -913,6 +921,7 @@
 		98B012BD1B82D6B000053A32 /* GeneratedCode */ = {
 			isa = PBXGroup;
 			children = (
+				A63FE9B91D97ED4D002D1A8A /* DependencyAnalyzer.Arguments.swift */,
 				98B012B71B82D67300053A32 /* Container.Arguments.swift */,
 				984774F91C02F5A50092A757 /* SynchronizedResolver.Arguments.swift */,
 				98B012BE1B82F68E00053A32 /* Resolvable.swift */,
@@ -1315,6 +1324,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A63FE9AD1D97EAE6002D1A8A /* DependencyAnalyzer.Arguments.erb in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1489,6 +1499,7 @@
 				984E8A811C319F090039943D /* SwinjectStoryboard.swift in Sources */,
 				90E70A551C16837300F12C2A /* PropertyRetrievable.swift in Sources */,
 				90D409F61C14E69F009DF1B1 /* JsonPropertyLoader.swift in Sources */,
+				A63FE9B81D97EAF1002D1A8A /* DependencyAnalyzer.swift in Sources */,
 				981899E41B5FFE5800C702D0 /* Container.swift in Sources */,
 				98B012B81B82D67300053A32 /* Container.Arguments.swift in Sources */,
 				9884E2A71B60B77400120259 /* ServiceKey.swift in Sources */,
@@ -1498,6 +1509,7 @@
 				984E8A851C319F090039943D /* SwinjectStoryboardType.swift in Sources */,
 				984774FA1C02F5A50092A757 /* SynchronizedResolver.Arguments.swift in Sources */,
 				90B029751C18599200A6A521 /* AssemblyType.swift in Sources */,
+				A63FE9BA1D97ED4D002D1A8A /* DependencyAnalyzer.Arguments.swift in Sources */,
 				984E8A7D1C319F090039943D /* Storyboard+Swizzling.swift in Sources */,
 				90E70A5A1C17279300F12C2A /* PropertyLoaderError.swift in Sources */,
 			);

--- a/Tests/Circularity.swift
+++ b/Tests/Circularity.swift
@@ -81,3 +81,35 @@ internal class DDependingOnBC: DType {
     weak var b: BType?
     weak var c: CType?
 }
+
+// MARK: -Circular dependency with an otuside Player X -> Y <-> Z
+
+internal protocol FType: AnyObject {}
+internal protocol GType: AnyObject {
+    var h: HType? {get set}
+    func foo() -> Bool
+}
+internal protocol HType: AnyObject {}
+
+internal class FDependindOnG: FType {
+    var gFooWasSuccessful: Bool = false
+    
+    init(g: GType) {
+        self.gFooWasSuccessful = g.foo()
+    }
+}
+
+internal class GDependingOnH: GType {
+    var h: HType?
+    
+    internal func foo() -> Bool {
+        return h != nil
+    }
+}
+
+internal class HDependingOnG: HType {
+    var g: GType
+    init(g: GType) {
+        self.g = g
+    }
+}

--- a/Tests/ContainerSpec.Circularity.swift
+++ b/Tests/ContainerSpec.Circularity.swift
@@ -145,6 +145,17 @@ class ContainerSpec_Circularity: QuickSpec {
                 expect(d.b as? BDependingOnC) === b
                 expect(d.c as? CDependingOnAD) === c
             }
+            it("resolves circular dependencies as soon as possible during the construction of the tree") {
+                container.register(FType.self) { r in FDependindOnG(g: r.resolve(GType.self)!) }
+                container.register(GType.self) { r in GDependingOnH() }
+                    .initCompleted { r, g in
+                        g.h = r.resolve(HType.self)
+                }
+                container.register(HType.self) { r in HDependingOnG(g: r.resolve(GType.self)!) }
+                
+                let f = container.resolve(FType.self)! as! FDependindOnG
+                expect(f.gFooWasSuccessful) == true
+            }
         }
     }
 }

--- a/Tests/ContainerSpec.Circularity.swift
+++ b/Tests/ContainerSpec.Circularity.swift
@@ -30,7 +30,7 @@ class ContainerSpec_Circularity: QuickSpec {
                     container.register(ChildType.self) { _ in Child() }
                         .initCompleted { r, s in
                             let child = s as! Child
-                            child.parent = r.resolve(ParentType.self)!
+                            child.parent = r.resolve(ParentType.self)
                         }
                         .inObjectScope(scope)
                     

--- a/Tests/ContainerSpec.swift
+++ b/Tests/ContainerSpec.swift
@@ -248,7 +248,7 @@ class ContainerSpec: QuickSpec {
                 container.register(PersonType.self) { _ in PetOwner() }
                     .initCompleted { r, s in
                         let owner = s as! PetOwner
-                        owner.pet = r.resolve(AnimalType.self)!
+                        owner.pet = r.resolve(AnimalType.self)
                     }
                 
                 let owner = container.resolve(PersonType.self) as! PetOwner
@@ -270,7 +270,7 @@ class ContainerSpec: QuickSpec {
                 container.register(PersonType.self) { _ in PetOwner() }
                     .initCompleted { r, s in
                         let owner = s as! PetOwner
-                        owner.injectAnimal(r.resolve(AnimalType.self)!)
+                        owner.injectAnimal(r.resolve(AnimalType.self))
                     }
                 
                 let owner = container.resolve(PersonType.self) as! PetOwner

--- a/Tests/PersonType.swift
+++ b/Tests/PersonType.swift
@@ -21,7 +21,7 @@ internal class PetOwner: PersonType {
         self.pet = pet
     }
     
-    func injectAnimal(animal: AnimalType) {
+    func injectAnimal(animal: AnimalType?) {
         self.pet = animal
     }
 }

--- a/Tests/SynchronizedResolverSpec.swift
+++ b/Tests/SynchronizedResolverSpec.swift
@@ -24,7 +24,7 @@ class SynchronizedResolverSpec: QuickSpec {
                     container.register(ChildType.self) { _ in Child() }
                         .initCompleted { r, s in
                             let child = s as! Child
-                            child.parent = r.resolve(ParentType.self)!
+                            child.parent = r.resolve(ParentType.self)
                         }
                         .inObjectScope(.Graph)
                 }.synchronize()

--- a/script/gencode
+++ b/script/gencode
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files="Sources/Container.Arguments Sources/SynchronizedResolver.Arguments Sources/Resolvable"
+files="Sources/Container.Arguments Sources/SynchronizedResolver.Arguments Sources/Resolvable Sources/DependencyAnalyzer.Arguments"
 
 for file in $files; do
   echo "Generating code to $file.swift"


### PR DESCRIPTION
Relevant #134 
Fixes #158 

Hi @yoichitgy 

Please take a look at a new approach to resolve dependency cycles without initiating objects twice.

The concept is only partially based on what I [wrote in the bug thread](https://github.com/Swinject/Swinject/issues/158#issuecomment-249362338). I could not think of a way to replace the Swift Optional with a reference type without breaking the API. So I took a different approach.

The PR is based on the premise that `initComplete` closures are not allowed to unwrap the Optionals resolved by the `Resolver`.  This should be in line with the [documentation](https://github.com/Swinject/Swinject/blob/v1/Documentation/CircularDependencies.md) but it will break code that tries to unwrap them (I had to remove force unwrapping from some Tests for this).

This PR enables Swinject to do two things:
- To investigate the dependencies needed by an `initComplete` closure using a [`DependencyAnalyzer`](https://github.com/marcorei/Swinject/blob/fix-dependency-cycle-injection/Sources/DependencyAnalyzer.swift) as the `Resolver`. It works by returning `nil` and saving the requested types.
- To call `initComplete` closures that only create new objects which are not in the process of being created.
- Then after each Objects initialization, pending `initComplete`s are checked and executed once all dependencies are created (that is: not currently being created).

The code might be rough by I though to pitch this idea to you before investing more time in this concept. 

Tests: 
- I added the case @petalvlad was describing.
- A case testing if storyboards are injected only once now fails because of the additional analysis run – I could not yet look into that issue.
- I had to remove force unwrapping from `initComplete` closures in tests.

Looking forward to your feedback!

Cheers,
Markus
