### PR TITLE
Update .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,13 @@ env:
     - DESTINATION="OS=2.2,name=Apple Watch - 42mm" SCHEME="Swinject-watchOS" SDK="$WATCHOS_SDK" PLATFORM="watchOS" POD_LINT="NO" ACTION="build"
     - DESTINATION="OS=3.0,name=Apple Watch - 42mm" SCHEME="Swinject-watchOS" SDK="$WATCHOS_SDK" PLATFORM="watchOS" POD_LINT="NO" ACTION="build"
 before_install:
-  - curl -L -O https://github.com/Carthage/Carthage/releases/download/0.17.2/Carthage.pkg
-  - sudo installer -pkg Carthage.pkg -target /
-  - carthage bootstrap --verbose --no-build --use-submodules
+  - git submodule update --recursive
 script:
   - set -o pipefail
   - xcodebuild -version
   - open -b com.apple.iphonesimulator # Workaround https://github.com/travis-ci/travis-ci/issues/3040
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" 
-    -configuration Release ENABLE_TESTABILITY=YES ONLY_ACTIVE_ARCH=NO $ACTION
+    -configuration Release ENABLE_TESTABILITY=YES ONLY_ACTIVE_ARCH=NO $ACTION | xcpretty
   - if [ $POD_LINT == "YES" ]; then
       pod lib lint --quick;
     fi


### PR DESCRIPTION
- Replace Carthage with `git submodule update` because using Carthage is redundant.
- Add xcpretty again because random test failure on travis didn't relate to xcpretty.