### PR TITLE
Change Assembler to `final class`

### DIFF
--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -8,7 +8,7 @@
 
 
 /// The `Assembler` provides a means to build a container via `AssemblyType` instances.
-public class Assembler {
+public final class Assembler {
     
     /// the container that each assembly will build its `Service` definitions into
     private let container: Container


### PR DESCRIPTION
Forbid inheritance of `Assembler` as discussed in PR #152.