### PR TITLE
Add @escaping to register factory closure

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -74,7 +74,7 @@ public final class Container {
     public func register<Service>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: (Resolver) -> Service) -> ServiceEntry<Service>
+        factory: @escaping (Resolver) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
     }


### PR DESCRIPTION
Fixes an issue that inadvertently works around the Swift 3 escaping closure requirement.

When creating a utility extension method to register simple values I noticed this simple implementation causes a random crash because the `value` always ends up nil.
```  
  func register<Service>(_ value: Service, name: String? = nil) {
    self.register(Service.self, name: name) { resolver in return value }
  }
```
After much debugging it appears that the public `register` method doesn't have the (Swift 3) required `@escaping` modifier.  This apparently causes the provided closure to go out of scope and not properly copy the value of parameters like `value`.  Modifying the `register` method's factory closure to be annotated with `@escaping` causes everything to work properly. 


The following method using `_register` instead also works properly:
```
  func register<Service>(_ value: Service, name: String? = nil) {
    self._register(Service.self, factory: { (resolver: ResolverType) -> Service in return value }, name: name, option: nil)
  }
```
I believe this is due to Swift 3 automatically figuring out the `@escaping` requirement properly because `_register`s factory closure type is inferred through generics.  This actually seems to clearly be a deficiency in the Swift 3 `@escaping` requirement rule system; it should catch the need for `@escaping` when passing from `register` to `_register`.
