### PR TITLE
Fix Any to AnyObject cast for linux environment

### DIFF
--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -33,10 +33,17 @@ public final class TransientStorage: InstanceStorage {
 public final class WeakStorage: InstanceStorage {
     private weak var object: AnyObject?
 
+    #if os(Linux)
+    public var instance: Any? {
+        get { return object }
+        set { object = newValue.flatMap { $0 as? AnyObject } }
+    }
+    #else
     public var instance: Any? {
         get { return object }
         set { object = newValue as AnyObject? }
     }
+    #endif
 
     public init () {}
 }


### PR DESCRIPTION
The issue: On non-darwin platofrms `Any` is not castable to `AnyObject`, while on darwin platform conditional cast of `Any` to `AnyObject` produces warning.