### PR TITLE
Fixed typo in logingFunction property

### DIFF
--- a/Sources/Container.Logging.swift
+++ b/Sources/Container.Logging.swift
@@ -11,14 +11,14 @@ public typealias LoggingFunctionType = (String) -> Void
 public extension Container {
     /// Function to be used for logging debugging data.
     /// Default implementation writes to standard output.
-    public static var logingFunction: LoggingFunctionType? {
-        get { return _logingFunction }
-        set { _logingFunction = newValue }
+    public static var loggingFunction: LoggingFunctionType? {
+        get { return _loggingFunction }
+        set { _loggingFunction = newValue }
     }
 
     internal static func log(_ message: String) {
-        _logingFunction?(message)
+        _loggingFunction?(message)
     }
 }
 
-private var _logingFunction: LoggingFunctionType? = { print($0) }
+private var _loggingFunction: LoggingFunctionType? = { print($0) }


### PR DESCRIPTION
Fixed #212 (`logingFunction` to `loggingFunction`)