### PR TITLE
Fix SwiftLint errors with the latest version

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -119,6 +119,7 @@ public final class Container {
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
     @discardableResult
+    // swiftlint:disable:next identifier_name
     public func _register<Service, Factory>(
         _ serviceType: Service.Type,
         factory: Factory,
@@ -142,6 +143,7 @@ public final class Container {
 
 // MARK: - _Resolver
 extension Container: _Resolver {
+    // swiftlint:disable:next identifier_name
     public func _resolve<Service, Factory>(name: String?, option: ServiceKeyOption? = nil, invoker: (Factory) -> Service) -> Service? {
         incrementResolutionDepth()
         defer { decrementResolutionDepth() }

--- a/Sources/SynchronizedResolver.swift
+++ b/Sources/SynchronizedResolver.swift
@@ -15,6 +15,7 @@ internal final class SynchronizedResolver {
 }
 
 extension SynchronizedResolver: _Resolver {
+    // swiftlint:disable:next identifier_name
     internal func _resolve<Service, Factory>(name: String?, option: ServiceKeyOption?, invoker: (Factory) -> Service) -> Service? {
         return container.lock.sync {
             return self.container._resolve(name: name, option: option, invoker: invoker)

--- a/Sources/_Resolver.swift
+++ b/Sources/_Resolver.swift
@@ -19,5 +19,6 @@ public protocol _Resolver {
     /// - Parameter invoker: A closure to execute service resolution.
     ///
     /// - Returns: The resolved service type instance, or nil if no service is found.
+    // swiftlint:disable:next identifier_name
     func _resolve<Service, Factory>(name: String?, option: ServiceKeyOption?, invoker: (Factory) -> Service) -> Service?
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** None
* **Related pull-requests:** None

### :tophat: What is the goal?

The latest version of SwiftLint (0.17.0) introduce a breaking change with rule `variable_name`.

### How is it being implemented?

Ignore the rule so the project can compile.