### PR TITLE
fix type reference on childContainer's resolve

### DIFF
--- a/Documentation/ContainerHierarchy.md
+++ b/Documentation/ContainerHierarchy.md
@@ -7,7 +7,7 @@ let parentContainer = Container()
 parentContainer.register(Animal.self) { _ in Cat() }
 let childContainer = Container(parent: parentContainer)
 
-let cat = childContainer.resolve(AnimalType.self)
+let cat = childContainer.resolve(Animal.self)
 print(cat != nil) // prints "true"
 ```
 


### PR DESCRIPTION
The intention of the code is to demonstrate, the childContainer can resolve a Type registered originally for its parentContainer.