### PR TITLE
Use the first argument label of Assembler

### DIFF
--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -38,12 +38,12 @@ public final class Assembler {
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter container:          the baseline container
     ///
-    @available(*, deprecated, message: "Use not throwing alternative: init(_:, container:)")
+    @available(*, deprecated, message: "Use not throwing alternative: init(assemblies:, container:)")
     public convenience init(assemblies: [Assembly], container: Container? = Container()) throws {
         if let container = container {
-            self.init(assemblies, container: container)
+            self.init(assemblies: assemblies, container: container)
         } else {
-            self.init(assemblies)
+            self.init(assemblies: assemblies)
         }
     }
 
@@ -52,7 +52,7 @@ public final class Assembler {
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter container:          the baseline container
     ///
-    public init(_ assemblies: [Assembly], container: Container = Container()) {
+    public init(assemblies: [Assembly], container: Container = Container()) {
         self.container = container
         run(assemblies: assemblies)
     }
@@ -62,9 +62,9 @@ public final class Assembler {
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter parentAssembler:    the baseline assembler
     ///
-    @available(*, deprecated, message: "Use not throwing alternative: init(_:, parent:)")
+    @available(*, deprecated, message: "Use not throwing alternative: init(assemblies:, parent:)")
     public convenience init(assemblies: [Assembly], parentAssembler: Assembler?) throws {
-        self.init(_: assemblies, parent: parentAssembler)
+        self.init(assemblies: assemblies, parent: parentAssembler)
     }
 
     /// Will create a new `Assembler` with the given `Assembly` instances to build a `Container`
@@ -72,7 +72,7 @@ public final class Assembler {
     /// - parameter assemblies: the list of assemblies to build the container from
     /// - parameter parent:     the baseline assembler
     ///
-    public init(_ assemblies: [Assembly], parent: Assembler?) {
+    public init(assemblies: [Assembly], parent: Assembler?) {
         container = Container(parent: parent?.container)
         run(assemblies: assemblies)
     }

--- a/Tests/SwinjectTests/AssemblerSpec.swift
+++ b/Tests/SwinjectTests/AssemblerSpec.swift
@@ -16,7 +16,7 @@ class AssemblerSpec: QuickSpec {
         
         describe("Assembler basic init") {
             it("can assembly a single container") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     AnimalAssembly()
                 ])
                 let cat = assembler.resolver.resolve(Animal.self)
@@ -35,7 +35,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a container with nil parent and assemblies") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     AnimalAssembly()
                 ], parent: nil)
                 let cat = assembler.resolver.resolve(Animal.self)
@@ -47,7 +47,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a multiple container") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     AnimalAssembly(),
                     FoodAssembly()
                 ])
@@ -61,7 +61,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a multiple container with inter dependencies") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     AnimalAssembly(),
                     FoodAssembly(),
                     PersonAssembly()
@@ -79,7 +79,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a multiple container with inter dependencies in any order") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     PersonAssembly(),
                     AnimalAssembly(),
                     FoodAssembly(),
@@ -99,7 +99,7 @@ class AssemblerSpec: QuickSpec {
         
         describe("Assembler lazy build") {
             it("can assembly a single container") {
-                let assembler = Assembler([])
+                let assembler = Assembler(assemblies: [])
                 var cat = assembler.resolver.resolve(Animal.self)
                 expect(cat).to(beNil())
                 
@@ -111,7 +111,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a single load aware container") {
-                let assembler = Assembler([])
+                let assembler = Assembler(assemblies: [])
                 var cat = assembler.resolver.resolve(Animal.self)
                 expect(cat).to(beNil())
                 
@@ -131,7 +131,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a multiple containers 1 by 1") {
-                let assembler = Assembler([])
+                let assembler = Assembler(assemblies: [])
                 var cat = assembler.resolver.resolve(Animal.self)
                 expect(cat).to(beNil())
                 
@@ -154,7 +154,7 @@ class AssemblerSpec: QuickSpec {
             }
             
             it("can assembly a multiple containers at once") {
-                let assembler = Assembler([])
+                let assembler = Assembler(assemblies: [])
                 var cat = assembler.resolver.resolve(Animal.self)
                 expect(cat).to(beNil())
                 
@@ -184,7 +184,7 @@ class AssemblerSpec: QuickSpec {
                 }
                 
                 expect(loadAwareAssembly.loaded) == false
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     loadAwareAssembly
                 ])
                 expect(loadAwareAssembly.loaded) == true
@@ -205,7 +205,7 @@ class AssemblerSpec: QuickSpec {
                 }
                 
                 expect(loadAwareAssembly.loaded) == false
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     loadAwareAssembly,
                     FoodAssembly()
                 ])
@@ -237,7 +237,7 @@ class AssemblerSpec: QuickSpec {
         
         describe("Child Assembler") {
             it("can be empty") {
-                let assembler = Assembler([
+                let assembler = Assembler(assemblies: [
                     AnimalAssembly()
                 ])
                 
@@ -258,7 +258,7 @@ class AssemblerSpec: QuickSpec {
             
             it("can't give entities to parent") {
                 let assembler = Assembler()
-                let childAssembler = Assembler([
+                let childAssembler = Assembler(assemblies: [
                     AnimalAssembly()
                 ], parent: assembler)
                 


### PR DESCRIPTION
@ManWithBear @jakubvano, I would like to discuss one thing before we release Swinject v2.1.0. We fixed the initializers of Assembler in #241, and we dropped the first argument like this with `_`:

```swift
init(_ assemblies: [Assembly], parent: Assembler?)
```

IMO, using the first argument label `assemblies` is a proper way because the initializer of Assembler is not for type conversion.
https://swift.org/documentation/api-design-guidelines/#argument-labels

What do you guys think about this?

I'll release v2.1.0 after discussing this (merging the pull request or just closing).