### PR TITLE
Add remark to the Container initializer taking a closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,17 +211,19 @@ Typically services are registered to a container in `AppDelegate` if you do not 
 ```swift
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    let container = Container() { c in
-        c.register(Animal.self) { _ in Cat(name: "Mimi") }
-        c.register(Person.self) { r in
+    let container: Container = {
+        let container = Container()
+        container.register(Animal.self) { _ in Cat(name: "Mimi") }
+        container.register(Person.self) { r in
             PetOwner(pet: r.resolve(Animal.self)!)
         }
-        c.register(PersonViewController.self) { r in
+        container.register(PersonViewController.self) { r in
             let controller = PersonViewController()
             controller.person = r.resolve(Person.self)
             return controller
         }
-    }
+        return container
+    }()
 
     func application(
         _ application: UIApplication,

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -47,6 +47,7 @@ public final class Container {
     /// - Parameters:
     ///     - parent:             The optional parent `Container`.
     ///     - registeringClosure: The closure registering services to the new container instance.
+    /// - Remark: Compile time may be long if you pass a long closure to this initializer. Use `init()` or `init(parent:)` instead.
     public convenience init(parent: Container? = nil, registeringClosure: (Container) -> Void) {
         self.init(parent: parent)
         registeringClosure(self)


### PR DESCRIPTION
Resolves #97.

- Update README to replace the usage of the initializer.
- Add remark to the initializer talking a closure.

@Lutzifer, do you think my changes can help users to avoid seeing the compile speed problem?