### PR TITLE
Set default parameter to `resolve` method in Container

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -201,7 +201,7 @@ extension Container: Resolver {
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type is found in the `Container`.
     public func resolve<Service>(
-        _ serviceType: Service.Type) -> Service?
+        _ serviceType: Service.Type = Service.self) -> Service?
     {
         return resolve(serviceType, name: nil)
     }
@@ -214,7 +214,7 @@ extension Container: Resolver {
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type and name is found in the `Container`.
     public func resolve<Service>(
-        _ serviceType: Service.Type,
+        _ serviceType: Service.Type = Service.self,
         name: String?) -> Service?
     {
         typealias FactoryType = (Resolver) -> Service

--- a/Tests/SwinjectTests/ContainerSpec.swift
+++ b/Tests/SwinjectTests/ContainerSpec.swift
@@ -49,6 +49,15 @@ class ContainerSpec: QuickSpec {
                 expect(mew.name) == "Mew"
                 expect(noname.name).to(beNil())
             }
+            it("resolves without type specification") {
+                container.register(Animal.self) { _ in Cat() }
+                let animal1: Animal? = container.resolve()
+                let animal2 = container.resolve() as Animal?
+                let cat: Cat? = container.resolve()
+                expect(animal1).notTo(beNil())
+                expect(animal2).notTo(beNil())
+                expect(cat).to(beNil())
+            }
         }
         describe("Removal of registered services") {
             it("can remove all registered services.") {

--- a/Tests/SwinjectTests/ContainerSpec.swift
+++ b/Tests/SwinjectTests/ContainerSpec.swift
@@ -53,9 +53,14 @@ class ContainerSpec: QuickSpec {
                 container.register(Animal.self) { _ in Cat() }
                 let animal1: Animal? = container.resolve()
                 let animal2 = container.resolve() as Animal?
-                let cat: Cat? = container.resolve()
+                let animal3: Animal! = container.resolve()
+                let _: Animal = container.resolve()!
+                
                 expect(animal1).notTo(beNil())
                 expect(animal2).notTo(beNil())
+                expect(animal3).notTo(beNil())
+                
+                let cat: Cat? = container.resolve()
                 expect(cat).to(beNil())
             }
         }


### PR DESCRIPTION
so that make it enable to resolve without type specification like below.

```swift
container.register(Animal.self) { _ in Cat() }
let animal: Animal = container.resolve()!
```
