### PR TITLE
Include xcconfig files in repo, instead of relying on them externally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "Carthage/Checkouts/Quick"]
 	path = Carthage/Checkouts/Quick
 	url = https://github.com/Quick/Quick.git
-[submodule "Carthage/Checkouts/xcconfigs"]
-	path = Carthage/Checkouts/xcconfigs
-	url = https://github.com/jspahrsummers/xcconfigs.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,2 @@
-github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"
 github "Quick/Quick" ~> 1.1
 github "Quick/Nimble" ~> 6.1

--- a/Configurations/Base/Common.xcconfig
+++ b/Configurations/Base/Common.xcconfig
@@ -1,0 +1,179 @@
+// 
+// This file defines common settings that should be enabled for every new
+// project. Typically, you want to use Debug, Release, or a similar variant
+// instead.
+//
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Architectures to build
+ARCHS = $(ARCHS_STANDARD)
+
+// Whether to warn when a floating-point value is used as a loop counter
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES
+
+// Whether to warn about use of rand() and random() being used instead of arc4random()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES
+
+// Whether to warn about strcpy() and strcat()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES
+
+// Whether to enable module imports
+CLANG_ENABLE_MODULES = YES
+
+// Enable ARC
+CLANG_ENABLE_OBJC_ARC = YES
+
+// Warn about implicit conversions to boolean values that are suspicious.
+// For example, writing 'if (foo)' with 'foo' being the name a function will trigger a warning.
+CLANG_WARN_BOOL_CONVERSION = YES
+
+// Warn about implicit conversions of constant values that cause the constant value to change,
+// either through a loss of precision, or entirely in its meaning.
+CLANG_WARN_CONSTANT_CONVERSION = YES
+
+// Whether to warn when overriding deprecated methods
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+
+// Warn about direct accesses to the Objective-C 'isa' pointer instead of using a runtime API.
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+// Warn about declaring the same method more than once within the same @interface.
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+
+// Warn about loop bodies that are suspiciously empty.
+CLANG_WARN_EMPTY_BODY = YES
+
+// Warn about implicit conversions between different kinds of enum values.
+// For example, this can catch issues when using the wrong enum flag as an argument to a function or method.
+CLANG_WARN_ENUM_CONVERSION = YES
+
+// Whether to warn on implicit conversions between signed/unsigned types
+CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
+
+// Warn about implicit conversions between pointers and integers.
+// For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
+CLANG_WARN_INT_CONVERSION = YES
+
+// Don't warn about repeatedly using a weak reference without assigning the weak reference to a strong reference. Too many false positives.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO
+
+// Warn about classes that unintentionally do not subclass a root class (such as NSObject).
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+// Whether to warn on suspicious implicit conversions
+CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
+
+// Warn about potentially unreachable code
+CLANG_WARN_UNREACHABLE_CODE = YES
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// Whether to compile assertions in
+ENABLE_NS_ASSERTIONS = YES
+
+// Whether to require objc_msgSend to be cast before invocation
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+// Which C variant to use
+GCC_C_LANGUAGE_STANDARD = gnu99
+
+// Whether to enable exceptions for Objective-C
+GCC_ENABLE_OBJC_EXCEPTIONS = YES
+
+// Whether to generate debugging symbols
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
+// Whether to precompile the prefix header (if one is specified)
+GCC_PRECOMPILE_PREFIX_HEADER = YES
+
+// Whether to enable strict aliasing, meaning that two pointers of different
+// types (other than void * or any id type) cannot point to the same memory
+// location
+GCC_STRICT_ALIASING = YES
+
+// Whether symbols not explicitly exported are hidden by default (this primarily
+// only affects C++ code)
+GCC_SYMBOLS_PRIVATE_EXTERN = NO
+
+// Whether static variables are thread-safe by default
+GCC_THREADSAFE_STATICS = NO
+
+// Which compiler to use
+GCC_VERSION = com.apple.compilers.llvm.clang.1_0
+
+// Whether warnings are treated as errors
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+
+// Whether to warn about 64-bit values being implicitly shortened to 32 bits
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+
+// Whether to warn about fields missing from structure initializers (only if
+// designated initializers aren't used)
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+
+// Whether to warn about missing function prototypes
+GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO
+
+// Whether to warn about implicit conversions in the signedness of the type
+// a pointer is pointing to (e.g., 'int *' getting converted to 'unsigned int *')
+GCC_WARN_ABOUT_POINTER_SIGNEDNESS = YES
+
+// Whether to warn when the value returned from a function/method/block does not
+// match its return type
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+// Whether to warn on a class not implementing all the required methods of
+// a protocol it declares conformance to
+GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
+
+// Whether to warn when switching on an enum value, and all possibilities are
+// not accounted for
+GCC_WARN_CHECK_SWITCH_STATEMENTS = YES
+
+// Whether to warn about the use of four-character constants
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+
+// Whether to warn about an aggregate data type's initializer not being fully
+// bracketed (e.g., array initializer syntax)
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+
+// Whether to warn about missing braces or parentheses that make the meaning of
+// the code ambiguous
+GCC_WARN_MISSING_PARENTHESES = YES
+
+// Whether to warn about unsafe comparisons between values of different
+// signedness
+GCC_WARN_SIGN_COMPARE = YES
+
+// Whether to warn about the arguments to printf-style functions not matching
+// the format specifiers
+GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
+
+// Warn if a "@selector(...)" expression referring to an undeclared selector is found
+GCC_WARN_UNDECLARED_SELECTOR = YES
+
+// Warn if a variable might be clobbered by a setjmp call or if an automatic variable is used without prior initialization.
+GCC_WARN_UNINITIALIZED_AUTOS = YES
+
+// Whether to warn about static functions that are unused
+GCC_WARN_UNUSED_FUNCTION = YES
+
+// Whether to warn about labels that are unused
+GCC_WARN_UNUSED_LABEL = YES
+
+// Whether to warn about variables that are never used
+GCC_WARN_UNUSED_VARIABLE = YES
+
+// Whether to run the static analyzer with every build
+RUN_CLANG_STATIC_ANALYZER = YES
+
+// Don't treat unknown warnings as errors, and disable GCC compatibility warnings and unused static const variable warnings
+WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable -Wno-nullability-completeness
+
+// This setting is on for new projects as of Xcode ~6.3, though it is still not
+// the default. It warns if the same variable is declared in two binaries that
+// are linked together.
+GCC_NO_COMMON_BLOCKS = YES

--- a/Configurations/Base/Configurations/Debug.xcconfig
+++ b/Configurations/Base/Configurations/Debug.xcconfig
@@ -1,0 +1,43 @@
+// 
+// This file defines the base configuration for a Debug build of any project.
+// This should be set at the project level for the Debug configuration.
+//
+
+#include "../Common.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = NO
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = 0
+
+// Preproccessor definitions to apply to each file compiled
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1
+
+// Whether to enable link-time optimizations (such as inlining across translation
+// units)
+LLVM_LTO = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = YES
+
+// Other compiler flags
+// 
+// These settings catch some errors in integer arithmetic
+OTHER_CFLAGS = -ftrapv
+
+// Other flags to pass to the Swift compiler
+//
+// This enables conditional compilation with #if DEBUG
+OTHER_SWIFT_FLAGS = -D DEBUG
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = NO
+
+// The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+
+// Disable Developer ID timestamping
+OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Configurations/Base/Configurations/Profile.xcconfig
+++ b/Configurations/Base/Configurations/Profile.xcconfig
@@ -1,0 +1,27 @@
+// 
+// This file defines the base configuration for an optional profiling-specific
+// build of any project. To use these settings, create a Profile configuration
+// in your project, and use this file at the project level for the new
+// configuration.
+//
+
+// based on the Release configuration, with some stuff related to debugging
+// symbols re-enabled
+#include "Release.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = YES
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = NO
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = NO
+
+// Disable Developer ID timestamping
+OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Configurations/Base/Configurations/Release.xcconfig
+++ b/Configurations/Base/Configurations/Release.xcconfig
@@ -1,0 +1,34 @@
+// 
+// This file defines the base configuration for a Release build of any project.
+// This should be set at the project level for the Release configuration.
+//
+
+#include "../Common.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = YES
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = s
+
+// Preproccessor definitions to apply to each file compiled
+GCC_PREPROCESSOR_DEFINITIONS = NDEBUG=1
+
+// Whether to enable link-time optimizations (such as inlining across translation
+// units)
+LLVM_LTO = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = NO
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = YES
+
+// The optimization level (-Onone, -O, -Owholemodule) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = YES
+

--- a/Configurations/Base/Configurations/Test.xcconfig
+++ b/Configurations/Base/Configurations/Test.xcconfig
@@ -1,0 +1,10 @@
+// 
+// This file defines the base configuration for a Test build of any project.
+// This should be set at the project level for the Test configuration.
+//
+
+#include "Debug.xcconfig"
+
+// Sandboxed apps can't be unit tested since they can't load some random 
+// external bundle. So we disable sandboxing for testing.
+CODE_SIGN_ENTITLEMENTS = 

--- a/Configurations/Base/Targets/Application.xcconfig
+++ b/Configurations/Base/Targets/Application.xcconfig
@@ -1,0 +1,12 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Sets the @rpath for the application such that it can include frameworks in
+// the application bundle (inside the "Frameworks" folder)
+LD_RUNPATH_SEARCH_PATHS = @executable_path/../Frameworks @loader_path/../Frameworks @executable_path/Frameworks

--- a/Configurations/Base/Targets/Framework.xcconfig
+++ b/Configurations/Base/Targets/Framework.xcconfig
@@ -1,0 +1,37 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Disable code signing for successful device builds with Xcode 8. Frameworks do
+// need to be signed, but they don't need to be signed at compile time because
+// they'll be re-signed when you include them in your app.
+CODE_SIGNING_REQUIRED = NO
+CODE_SIGN_IDENTITY = 
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether this framework should define an LLVM module
+DEFINES_MODULE = YES
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Default frameworks to the name of the project, instead of any
+// platform-specific target
+PRODUCT_NAME = $(PROJECT_NAME)
+
+// Enables the framework to be included from any location as long as the
+// loader’s runpath search paths includes it. For example from an application
+// bundle (inside the "Frameworks" folder) or shared folder
+INSTALL_PATH = @rpath
+LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
+SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES

--- a/Configurations/Base/Targets/StaticLibrary.xcconfig
+++ b/Configurations/Base/Targets/StaticLibrary.xcconfig
@@ -1,0 +1,32 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries).
+//
+// Overrides Release.xcconfig when used at the target level.
+COPY_PHASE_STRIP = NO
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Copy headers to "include/LibraryName" in the build folder by default. This
+// lets consumers use #import <LibraryName/LibraryName.h> syntax even for static
+// libraries
+PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES
+

--- a/Configurations/Mac OS X/Mac-Application.xcconfig
+++ b/Configurations/Mac OS X/Mac-Application.xcconfig
@@ -1,0 +1,15 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on Mac OS X. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to Mac OS X
+#include "Mac-Base.xcconfig"
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = YES

--- a/Configurations/Mac OS X/Mac-Base.xcconfig
+++ b/Configurations/Mac OS X/Mac-Base.xcconfig
@@ -1,0 +1,19 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for Mac OS X. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Whether to combine multiple image resolutions into a multirepresentational
+// TIFF
+COMBINE_HIDPI_IMAGES = YES
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = macosx
+
+// Supported build architectures
+VALID_ARCHS = x86_64

--- a/Configurations/Mac OS X/Mac-DynamicLibrary.xcconfig
+++ b/Configurations/Mac OS X/Mac-DynamicLibrary.xcconfig
@@ -1,0 +1,18 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a dynamic library on Mac OS X. This should be set at the target level
+// for each project configuration.
+//
+
+// Import common settings specific to Mac OS X
+#include "Mac-Base.xcconfig"
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES

--- a/Configurations/Mac OS X/Mac-Framework.xcconfig
+++ b/Configurations/Mac OS X/Mac-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on OS X. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to Mac OS X
+#include "Mac-Base.xcconfig"

--- a/Configurations/Mac OS X/Mac-StaticLibrary.xcconfig
+++ b/Configurations/Mac OS X/Mac-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on Mac OS X. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to Mac OS X
+#include "Mac-Base.xcconfig"

--- a/Configurations/iOS/iOS-Application.xcconfig
+++ b/Configurations/iOS/iOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Configurations/iOS/iOS-Base.xcconfig
+++ b/Configurations/iOS/iOS-Base.xcconfig
@@ -1,0 +1,18 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for iOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Xcode needs this to find archived headers if SKIP_INSTALL is set
+HEADER_SEARCH_PATHS = $(OBJROOT)/UninstalledProducts/include
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = iphoneos
+
+// Supported device families (1 is iPhone, 2 is iPad)
+TARGETED_DEVICE_FAMILY = 1,2

--- a/Configurations/iOS/iOS-Framework.xcconfig
+++ b/Configurations/iOS/iOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Configurations/iOS/iOS-StaticLibrary.xcconfig
+++ b/Configurations/iOS/iOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Configurations/tvOS/tvOS-Application.xcconfig
+++ b/Configurations/tvOS/tvOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on tvOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to tvOS
+#include "tvOS-Base.xcconfig"

--- a/Configurations/tvOS/tvOS-Base.xcconfig
+++ b/Configurations/tvOS/tvOS-Base.xcconfig
@@ -1,0 +1,15 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for tvOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = appletvos
+
+// Supported device families
+TARGETED_DEVICE_FAMILY = 3

--- a/Configurations/tvOS/tvOS-Framework.xcconfig
+++ b/Configurations/tvOS/tvOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on tvOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "tvOS-Base.xcconfig"

--- a/Configurations/tvOS/tvOS-StaticLibrary.xcconfig
+++ b/Configurations/tvOS/tvOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on tvOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to tvOS
+#include "tvOS-Base.xcconfig"

--- a/Configurations/watchOS/watchOS-Application.xcconfig
+++ b/Configurations/watchOS/watchOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on watchOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to watchOS
+#include "watchOS-Base.xcconfig"

--- a/Configurations/watchOS/watchOS-Base.xcconfig
+++ b/Configurations/watchOS/watchOS-Base.xcconfig
@@ -1,0 +1,15 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for watchOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = watchos
+
+// Supported device families
+TARGETED_DEVICE_FAMILY = 4

--- a/Configurations/watchOS/watchOS-Framework.xcconfig
+++ b/Configurations/watchOS/watchOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on watchOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "watchOS-Base.xcconfig"

--- a/Configurations/watchOS/watchOS-StaticLibrary.xcconfig
+++ b/Configurations/watchOS/watchOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on watchOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to watchOS
+#include "watchOS-Base.xcconfig"

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -579,17 +579,17 @@
 			isa = PBXGroup;
 			children = (
 				98383A3C1C1AF76400733248 /* Quick.framework */,
-				98383A3E1C1AF76400733248 /* Quick-macOSTests.xctest */,
-				98383A401C1AF76400733248 /* QuickFocused-macOSTests.xctest */,
-				CDB572981DF6A33600D3785D /* QuickAfterSuite-macOSTests.xctest */,
+				98383A3E1C1AF76400733248 /* Quick - macOSTests.xctest */,
+				98383A401C1AF76400733248 /* QuickFocused - macOSTests.xctest */,
+				CDB572981DF6A33600D3785D /* QuickAfterSuite - macOSTests.xctest */,
 				98383A421C1AF76400733248 /* Quick.framework */,
-				98383A441C1AF76400733248 /* Quick-iOSTests.xctest */,
-				98383A461C1AF76400733248 /* QuickFocused-iOSTests.xctest */,
-				CDB5729A1DF6A33600D3785D /* QuickAfterSuite-iOSTests.xctest */,
+				98383A441C1AF76400733248 /* Quick - iOSTests.xctest */,
+				98383A461C1AF76400733248 /* QuickFocused - iOSTests.xctest */,
+				CDB5729A1DF6A33600D3785D /* QuickAfterSuite - iOSTests.xctest */,
 				98383A481C1AF76400733248 /* Quick.framework */,
-				98383A4A1C1AF76400733248 /* Quick-tvOSTests.xctest */,
-				98383A4C1C1AF76400733248 /* QuickFocused-tvOSTests.xctest */,
-				CDB5729C1DF6A33600D3785D /* QuickAfterSuite-tvOSTests.xctest */,
+				98383A4A1C1AF76400733248 /* Quick - tvOSTests.xctest */,
+				98383A4C1C1AF76400733248 /* QuickFocused - tvOSTests.xctest */,
+				CDB5729C1DF6A33600D3785D /* QuickAfterSuite - tvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -602,8 +602,7 @@
 				985010BF1BBE76AB00A2CCFC /* watchOS-Framework.xcconfig */,
 				985010C01BBE76AB00A2CCFC /* watchOS-StaticLibrary.xcconfig */,
 			);
-			name = watchOS;
-			path = Carthage/Checkouts/xcconfigs/watchOS;
+			path = watchOS;
 			sourceTree = "<group>";
 		};
 		98689C751BBFC77F0005C6D3 /* tvOS */ = {
@@ -615,7 +614,7 @@
 				98689C791BBFC77F0005C6D3 /* tvOS-StaticLibrary.xcconfig */,
 			);
 			name = tvOS;
-			path = Carthage/Checkouts/xcconfigs/tvOS;
+			path = Configurations/tvOS;
 			sourceTree = SOURCE_ROOT;
 		};
 		9878C63A1B65CA0600CBEFEF /* Fakes */ = {
@@ -637,10 +636,11 @@
 				98AA74451BB70CBB00E2F48A /* Base */,
 				98AA74501BB70CBB00E2F48A /* iOS */,
 				98AA74551BB70CBB00E2F48A /* Mac OS X */,
-				985010BC1BBE76AB00A2CCFC /* watchOS */,
 				98689C751BBFC77F0005C6D3 /* tvOS */,
+				985010BC1BBE76AB00A2CCFC /* watchOS */,
 			);
 			name = Configuration;
+			path = Configurations;
 			sourceTree = "<group>";
 		};
 		98AA74451BB70CBB00E2F48A /* Base */ = {
@@ -650,8 +650,7 @@
 				98AA74471BB70CBB00E2F48A /* Configurations */,
 				98AA744C1BB70CBB00E2F48A /* Targets */,
 			);
-			name = Base;
-			path = Carthage/Checkouts/xcconfigs/Base;
+			path = Base;
 			sourceTree = "<group>";
 		};
 		98AA74471BB70CBB00E2F48A /* Configurations */ = {
@@ -683,8 +682,7 @@
 				98AA74531BB70CBB00E2F48A /* iOS-Framework.xcconfig */,
 				98AA74541BB70CBB00E2F48A /* iOS-StaticLibrary.xcconfig */,
 			);
-			name = iOS;
-			path = Carthage/Checkouts/xcconfigs/iOS;
+			path = iOS;
 			sourceTree = "<group>";
 		};
 		98AA74551BB70CBB00E2F48A /* Mac OS X */ = {
@@ -696,8 +694,7 @@
 				98AA74591BB70CBB00E2F48A /* Mac-Framework.xcconfig */,
 				98AA745A1BB70CBB00E2F48A /* Mac-StaticLibrary.xcconfig */,
 			);
-			name = "Mac OS X";
-			path = "Carthage/Checkouts/xcconfigs/Mac OS X";
+			path = "Mac OS X";
 			sourceTree = "<group>";
 		};
 		98B012BD1B82D6B000053A32 /* GeneratedCode */ = {
@@ -1000,17 +997,17 @@
 			remoteRef = 98383A3B1C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A3E1C1AF76400733248 /* Quick-macOSTests.xctest */ = {
+		98383A3E1C1AF76400733248 /* Quick - macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "Quick-macOSTests.xctest";
+			path = "Quick - macOSTests.xctest";
 			remoteRef = 98383A3D1C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A401C1AF76400733248 /* QuickFocused-macOSTests.xctest */ = {
+		98383A401C1AF76400733248 /* QuickFocused - macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickFocused-macOSTests.xctest";
+			path = "QuickFocused - macOSTests.xctest";
 			remoteRef = 98383A3F1C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1021,17 +1018,17 @@
 			remoteRef = 98383A411C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A441C1AF76400733248 /* Quick-iOSTests.xctest */ = {
+		98383A441C1AF76400733248 /* Quick - iOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "Quick-iOSTests.xctest";
+			path = "Quick - iOSTests.xctest";
 			remoteRef = 98383A431C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A461C1AF76400733248 /* QuickFocused-iOSTests.xctest */ = {
+		98383A461C1AF76400733248 /* QuickFocused - iOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickFocused-iOSTests.xctest";
+			path = "QuickFocused - iOSTests.xctest";
 			remoteRef = 98383A451C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1042,38 +1039,38 @@
 			remoteRef = 98383A471C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A4A1C1AF76400733248 /* Quick-tvOSTests.xctest */ = {
+		98383A4A1C1AF76400733248 /* Quick - tvOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "Quick-tvOSTests.xctest";
+			path = "Quick - tvOSTests.xctest";
 			remoteRef = 98383A491C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98383A4C1C1AF76400733248 /* QuickFocused-tvOSTests.xctest */ = {
+		98383A4C1C1AF76400733248 /* QuickFocused - tvOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickFocused-tvOSTests.xctest";
+			path = "QuickFocused - tvOSTests.xctest";
 			remoteRef = 98383A4B1C1AF76400733248 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CDB572981DF6A33600D3785D /* QuickAfterSuite-macOSTests.xctest */ = {
+		CDB572981DF6A33600D3785D /* QuickAfterSuite - macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickAfterSuite-macOSTests.xctest";
+			path = "QuickAfterSuite - macOSTests.xctest";
 			remoteRef = CDB572971DF6A33600D3785D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CDB5729A1DF6A33600D3785D /* QuickAfterSuite-iOSTests.xctest */ = {
+		CDB5729A1DF6A33600D3785D /* QuickAfterSuite - iOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickAfterSuite-iOSTests.xctest";
+			path = "QuickAfterSuite - iOSTests.xctest";
 			remoteRef = CDB572991DF6A33600D3785D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CDB5729C1DF6A33600D3785D /* QuickAfterSuite-tvOSTests.xctest */ = {
+		CDB5729C1DF6A33600D3785D /* QuickAfterSuite - tvOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickAfterSuite-tvOSTests.xctest";
+			path = "QuickAfterSuite - tvOSTests.xctest";
 			remoteRef = CDB5729B1DF6A33600D3785D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};


### PR DESCRIPTION
I believe there's an issue using `SwinjectStoryboard` (at master where the xcconfigs are included in the repo) with `Swinject` (where the current release does not have the configs included in the repo) through Carthage. Something gets messed up where the project is expecting them at one location, but they're actually in the `Carthage/Checkouts` directory.

This should fix it.