### PR TITLE
Fixed segmentation crash on Xcode 9

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "Swinject",
     dependencies: [
         .Package(url: "https://github.com/Quick/Quick", majorVersion: 1),
-        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5, minor: 1),
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5, minor: 1)
     ]
 )

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -242,7 +242,7 @@ extension Container: Resolver {
         }
         entry.storage.instance = resolvedInstance as Any
 
-        if let completed = entry.initCompleted as? (Resolver, Service) -> () {
+        if let completed = entry.initCompleted as? (Resolver, Service) -> Void {
             completed(self, resolvedInstance)
         }
         return resolvedInstance

--- a/Sources/DebugHelper.swift
+++ b/Sources/DebugHelper.swift
@@ -24,7 +24,7 @@ internal final class LoggingDebugHelper: DebugHelper {
         var output = [
             "Swinject: Resolution failed. Expected registration:",
             "\t{ \(description(serviceType: serviceType, serviceKey: key)) }",
-            "Available registrations:",
+            "Available registrations:"
         ]
         output += availableRegistrations
             .filter { $0.1 is ServiceEntry<Service> }

--- a/Sources/ObjectScope.Standard.swift
+++ b/Sources/ObjectScope.Standard.swift
@@ -9,17 +9,17 @@
 extension ObjectScope {
     /// A new instance is always created by the `Container` when a type is resolved.
     /// The instance is not shared.
-    public static let transient = ObjectScope(storageFactory: TransientStorage.init, description: "transient")
+    public static let transient = ObjectScope(storageFactory: { TransientStorage() }, description: "transient")
 
     /// Instances are shared only when an object graph is being created,
     /// otherwise a new instance is created by the `Container`. This is the default scope.
-    public static let graph = ObjectScope(storageFactory: PermanentStorage.init, description: "graph")
+    public static let graph = ObjectScope(storageFactory: { PermanentStorage() }, description: "graph")
 
     /// An instance provided by the `Container` is shared within the `Container` and its child `Containers`.
-    public static let container = ObjectScope(storageFactory: PermanentStorage.init, description: "container")
+    public static let container = ObjectScope(storageFactory: { PermanentStorage() }, description: "container")
 
     /// An instance provided by the `Container` is shared within the `Container` and its child `Container`s 
     /// as long as there are strong references to given instance. Otherwise new instance is created
     /// when resolving the type.
-    public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak")
+    public static let weak = ObjectScope(storageFactory: { WeakStorage() }, description: "weak")
 }

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -70,7 +70,7 @@ public final class ServiceEntry<Service> {
     ///
     /// - Returns: `self` to add another configuration fluently.
     @discardableResult
-    public func initCompleted(_ completed: @escaping (Resolver, Service) -> ()) -> Self {
+    public func initCompleted(_ completed: @escaping (Resolver, Service) -> Void) -> Self {
         initCompleted = completed
         return self
     }


### PR DESCRIPTION
The problem was related to sending the `init` method on the storage factories in as a function pointer.