### PR TITLE
Add RegistryType

### DIFF
--- a/Sample-iOS.playground/Contents.swift
+++ b/Sample-iOS.playground/Contents.swift
@@ -390,3 +390,28 @@ var turtle2 = container5.resolve(Animal.self)!
 turtle1.name = "Laph"
 print(turtle1.name!)
 print(turtle2.name!)
+
+/*:
+## Using RegistryType
+*/
+
+// Implement the RegistryType to enum
+enum ZooType: String, RegistryType {
+	case ueno
+	case asahiyama
+	
+	var name: String {
+		return rawValue
+	}
+}
+
+let containerRegistryType = Container()
+
+containerRegistryType.register(Animal.self, registryType: ZooType.ueno) { _ in Cat(name: "Tama") }
+containerRegistryType.register(Animal.self, registryType: ZooType.asahiyama) { _ in Cat(name: "Kotetsu") }
+
+let ueno = containerRegistryType.resolve(Animal.self, registryType: ZooType.ueno)!
+let asahiyama = containerRegistryType.resolve(Animal.self, registryType: ZooType.asahiyama)!
+
+print(ueno.name)
+print(asahiyama.name)

--- a/Sources/RegistryType.swift
+++ b/Sources/RegistryType.swift
@@ -1,0 +1,39 @@
+//
+//  RegistryType.swift
+//  Swinject-iOS
+//
+//  Created by matsuokah on 2017/08/17.
+//  Copyright © 2017年 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+/// The `RegistryType` protocol helps to realize specifying the desirable registration without String.
+public protocol RegistryType {
+    var name: String { get }
+}
+
+// MARK: - Container
+public extension Container {
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration type, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver) -> Service
+        ) -> ServiceEntry<Service> {
+        return _register(serviceType, factory: factory, name: registryType.name)
+    }
+}

--- a/Sources/Resolver.erb
+++ b/Sources/Resolver.erb
@@ -67,3 +67,41 @@ public protocol Resolver {
 <% end %>
 
 }
+
+// MARK: - Resolver for RegistryType
+public extension Resolver {
+    /// Retrieves the instance with the specified service type and registration type.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the registry type is found.
+    func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service? {
+        return resolve(serviceType, name: registryType.name)
+    }
+
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_param = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "list of #{i} arguments" %>
+<%   arg_param_delegation = i == 1 ? "argument: argument" : "arguments: " + (1..i).map{ |n| "arg#{n}" }.join(", ") %>
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            <%= arg_param_description %> and the registry type is found.
+    func resolve<Service, <%= arg_types %>>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      <%= arg_param %>) -> Service? {
+        return resolve(serviceType, name: registryType.name, <%= arg_param_delegation %>)
+    }
+<% end %>
+
+}

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -268,3 +268,154 @@ public protocol Resolver {
 
 
 }
+
+// MARK: - Resolver for RegistryType
+public extension Resolver {
+    /// Retrieves the instance with the specified service type and registration type.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the registry type is found.
+    func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service? {
+        return resolve(serviceType, name: registryType.name)
+    }
+
+    /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            1 argument and the registry type is found.
+    func resolve<Service, Arg1>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      argument: Arg1) -> Service? {
+        return resolve(serviceType, name: registryType.name, argument: argument)
+    }
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 2 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2)
+    }
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 3 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3)
+    }
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 4 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4)
+    }
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 5 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 6 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 7 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 8 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 9 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service? {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
+}

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6742CE561F459F6900F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE571F45A42E00F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE581F45A43300F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE591F45A43A00F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
 		90B029751C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
 		90B029761C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
 		90B029771C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
@@ -211,6 +215,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6742CE551F459F6900F6B648 /* RegistryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryType.swift; sourceTree = "<group>"; };
 		90B029741C18599200A6A521 /* Assembly.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembly.swift; sourceTree = "<group>"; };
 		90B029781C185B1600A6A521 /* Assembler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembler.swift; sourceTree = "<group>"; };
 		90B0297E1C18666200A6A521 /* AssemblerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssemblerSpec.swift; sourceTree = "<group>"; };
@@ -233,7 +238,7 @@
 		984774F41C02F4EA0092A757 /* SynchronizedResolver.Arguments.erb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SynchronizedResolver.Arguments.erb; sourceTree = "<group>"; };
 		984774F91C02F5A50092A757 /* SynchronizedResolver.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolver.Arguments.swift; sourceTree = "<group>"; };
 		984774FE1C034C5C0092A757 /* SynchronizedResolverSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolverSpec.swift; sourceTree = "<group>"; };
-		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; };
+		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9848611B1B6F9B7000C07072 /* ContainerSpec.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerSpec.Arguments.swift; sourceTree = "<group>"; };
 		984BE3121CDA3FCF00BCF2AC /* _Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Resolver.swift; sourceTree = "<group>"; };
 		984E8A511C317AC90039943D /* Swinject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swinject.h; sourceTree = "<group>"; };
@@ -419,6 +424,7 @@
 				CD3B32911DD6121500B208A3 /* InstanceStorage.swift */,
 				984BE3121CDA3FCF00BCF2AC /* _Resolver.swift */,
 				98B012C11B82F70A00053A32 /* Resolver.erb */,
+				6742CE551F459F6900F6B648 /* RegistryType.swift */,
 				983B98301C06ECB2006A23D4 /* SpinLock.swift */,
 				98E550C21DEF066300BE6304 /* UnavailableItems.swift */,
 				98B012BD1B82D6B000053A32 /* GeneratedCode */,
@@ -877,6 +883,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE571F45A42E00F6B648 /* RegistryType.swift in Sources */,
 				983B98321C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				985BAFAA1B625E0F0055F998 /* ServiceEntry.swift in Sources */,
 				CD3B32981DD6126E00B208A3 /* ObjectScope.Standard.swift in Sources */,
@@ -929,6 +936,7 @@
 				90B029791C185B1600A6A521 /* Assembler.swift in Sources */,
 				9880E70E1C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				CD3B32971DD6126E00B208A3 /* ObjectScope.Standard.swift in Sources */,
+				6742CE561F459F6900F6B648 /* RegistryType.swift in Sources */,
 				985BAFA91B625E0F0055F998 /* ServiceEntry.swift in Sources */,
 				984774F01C02F25D0092A757 /* SynchronizedResolver.swift in Sources */,
 				CD3C2CDF1D98E47000863421 /* DebugHelper.swift in Sources */,
@@ -974,6 +982,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE581F45A43300F6B648 /* RegistryType.swift in Sources */,
 				983B98331C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				9880E7101C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				985011221BBE7E8900A2CCFC /* ObjectScope.swift in Sources */,
@@ -998,6 +1007,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE591F45A43A00F6B648 /* RegistryType.swift in Sources */,
 				90B0297D1C185B2200A6A521 /* Assembly.swift in Sources */,
 				983B98341C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				9880E7111C09EE2900ED5293 /* FunctionType.swift in Sources */,


### PR DESCRIPTION
Add RegistryType to specify the registration without String.

## Motivation
In my opinion, specifying the registration from String is little fragile.
And I want to specify it by enum.

So, in my project, I write like below.

```swift
enum RegistrationType: String {
  case A
  case B
  
  var name: String {
    return rawValue
  }
}

let registration = container.resolve(Class.self, name: RegistrationType.A.name)
```

But, I do not want to write the `.name`, because that is a little wordy, then I create this pull request.


Best regards.