### PR TITLE
Add RegistryType

### DIFF
--- a/Sample-iOS.playground/Contents.swift
+++ b/Sample-iOS.playground/Contents.swift
@@ -19,7 +19,7 @@ class Cat: Animal {
     init(name: String?) {
         self.name = name
     }
-    
+
     func sound() -> String {
         return "Meow!"
     }
@@ -226,6 +226,7 @@ class Horse: Animal {
 // but the factory with the arguments is recognized as a different registration to resolve.
 container.register(Animal.self) { _, name in Horse(name: name) }
 container.register(Animal.self) { _, name, running in Horse(name: name, running: running) }
+container.register(Cat.self) { _, name in Cat(name: name) }
 
 // The arguments to the factory are specified on the resolution.
 // If you pass an argument, pass it to `argument` parameter.

--- a/Sample-iOS.playground/Contents.swift
+++ b/Sample-iOS.playground/Contents.swift
@@ -391,3 +391,32 @@ var turtle2 = container5.resolve(Animal.self)!
 turtle1.name = "Laph"
 print(turtle1.name!)
 print(turtle2.name!)
+
+/*:
+## Using RegistryType
+*/
+
+// Implement the RegistryType to enum
+enum ZooType: String, RegistryType {
+    case ueno
+    case asahiyama
+    case tobu
+    
+    var name: String {
+        return rawValue
+    }
+}
+
+let containerRegistryType = Container()
+
+containerRegistryType.register(Animal.self, registryType: ZooType.ueno) { _ in Horse(name: "Noir") }
+containerRegistryType.register(Animal.self, registryType: ZooType.asahiyama) { _ in Horse(name: "Brandy") }
+containerRegistryType.register(Animal.self, registryType: ZooType.tobu) { _, name in Horse(name: name) }
+
+let uenoHorse = containerRegistryType.resolve(Animal.self, registryType: ZooType.ueno)!
+let asahiyamaHorse = containerRegistryType.resolve(Animal.self, registryType: ZooType.asahiyama)!
+let tobuHorse = containerRegistryType.resolve(Animal.self, registryType: ZooType.tobu, argument: "Autumn") as! Horse
+
+print(uenoHorse.name!)
+print(asahiyamaHorse.name!)
+print(tobuHorse.name!)

--- a/Sample-iOS.playground/timeline.xctimeline
+++ b/Sample-iOS.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -44,6 +44,27 @@ extension Container {
         return _register(serviceType, factory: factory, name: name)
     }
 
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, <%= arg_types %>) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
 <% end %>
 }
 
@@ -56,6 +77,7 @@ extension Container {
 <%   arg_param_name = i == 1 ? "argument" : "arguments" %>
 <%   arg_param_type = i == 1 ? arg_types : "(" + arg_types + ")" %>
 <%   arg_param_description = i == 1 ? "#{i} argument" : "list of #{i} arguments" %>
+<%   arg_param_delegation = i == 1 ? "argument: argument" : "arguments: " + (1..i).map{ |n| "arg#{n}" }.join(", ") %>
     /// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
     ///
     /// - Parameters:
@@ -89,5 +111,23 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, <%= arg_param_call %>) }
     }
 
+    /// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and <%= arg_param_description %> is found in the `Container`.
+    public func resolve<Service, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        <%= arg_param_def %>) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, <%= arg_param_name %>: <%= arg_param_call %>)
+    }
+
 <% end %>
 }
+

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -43,6 +43,27 @@ extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
@@ -59,6 +80,27 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -85,6 +127,27 @@ extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
@@ -101,6 +164,27 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -127,6 +211,27 @@ extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
@@ -143,6 +248,27 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -169,6 +295,27 @@ extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
@@ -190,6 +337,27 @@ extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
@@ -206,6 +374,27 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration name, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service) -> ServiceEntry<Service>
+    {
+        return register(serviceType, name: registryType.name, factory: factory)
     }
 
 }
@@ -245,6 +434,23 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, argument) }
     }
 
+    /// Retrieves the instance with the specified service type and 1 argument to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and 1 argument is found in the `Container`.
+    public func resolve<Service, Arg1>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        argument: Arg1) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, argument: argument)
+    }
+
     /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -276,6 +482,23 @@ extension Container {
     {
         typealias FactoryType = (Resolver, Arg1, Arg2) -> Service
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2) }
+    }
+
+    /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 2 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2)
     }
 
     /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
@@ -311,6 +534,23 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3) }
     }
 
+    /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 3 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3)
+    }
+
     /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -342,6 +582,23 @@ extension Container {
     {
         typealias FactoryType = (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4) }
+    }
+
+    /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 4 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4)
     }
 
     /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
@@ -377,6 +634,23 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5) }
     }
 
+    /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 5 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
     /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -408,6 +682,23 @@ extension Container {
     {
         typealias FactoryType = (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6) }
+    }
+
+    /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 6 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
     }
 
     /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
@@ -443,6 +734,23 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7) }
     }
 
+    /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 7 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
     /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -474,6 +782,23 @@ extension Container {
     {
         typealias FactoryType = (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) }
+    }
+
+    /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 8 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
     }
 
     /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
@@ -509,4 +834,22 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) }
     }
 
+    /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration name.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type
+    ///            and list of 9 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
+        return resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
 }
+

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -110,6 +110,28 @@ public final class Container {
         return _register(serviceType, factory: factory, name: name)
     }
 
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to register.
+    ///   - registryType: A registration type, which is used to differentiate from other registrations
+    ///                   that have the same service and factory types.
+    ///   - factory:      The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                   It is invoked when the `Container` needs to instantiate the instance.
+    ///                   It takes a `Resolver` to inject dependencies to the instance,
+    ///                   and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        factory: @escaping (Resolver) -> Service
+        ) -> ServiceEntry<Service> {
+        return register(serviceType, name: registryType.name, factory: factory)
+    }
+
     /// This method is designed for the use to extend Swinject functionality.
     /// Do NOT use this method unless you intend to write an extension or plugin to Swinject framework.
     ///
@@ -225,6 +247,18 @@ extension Container: Resolver {
     public func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service? {
         typealias FactoryType = (Resolver) -> Service
         return _resolve(name: name) { (factory: FactoryType) in factory(self) }
+    }
+
+    /// Retrieves the instance with the specified service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:  The service type to resolve.
+    ///   - registryType: The registration type.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type and name
+    ///            is found in the `Container`.
+    public func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service? {
+        return resolve(serviceType, name: registryType.name)
     }
 
     fileprivate func getEntry<Service>(_ key: ServiceKey) -> ServiceEntry<Service>? {

--- a/Sources/RegistryType.swift
+++ b/Sources/RegistryType.swift
@@ -1,0 +1,14 @@
+//
+//  RegistryType.swift
+//  Swinject-iOS
+//
+//  Created by matsuokah on 2017/08/17.
+//  Copyright © 2017年 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+/// The `RegistryType` protocol helps to realize specifying the desirable registration without String.
+public protocol RegistryType {
+    var name: String { get }
+}

--- a/Sources/Resolver.erb
+++ b/Sources/Resolver.erb
@@ -33,11 +33,21 @@ public protocol Resolver {
     /// - Returns: The resolved service type instance, or nil if no service with the name is found.
     func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service?
 
+    /// Retrieves the instance with the specified service type and registration type.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the registry type is found.
+    func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service?
+
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
 <%   arg_param = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
 <%   arg_param_name = i == 1 ? "argument" : "arguments" %>
 <%   arg_param_description = i == 1 ? "#{i} argument" : "list of #{i} arguments" %>
+<%   arg_param_delegation = i == 1 ? "argument: argument" : "arguments: " + (1..i).map{ |n| "arg#{n}" }.join(", ") %>
     /// Retrieves the instance with the specified service type and <%= arg_param_description %> to the factory closure.
     ///
     /// - Parameters:
@@ -64,6 +74,20 @@ public protocol Resolver {
         name: String?,
         <%= arg_param %>) -> Service?
 
-<% end %>
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            <%= arg_param_description %> and the registry type is found.
+    func resolve<Service, <%= arg_types %>>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      <%= arg_param %>) -> Service?
 
+<% end %>
 }
+

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -32,6 +32,15 @@ public protocol Resolver {
     /// - Returns: The resolved service type instance, or nil if no service with the name is found.
     func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service?
 
+    /// Retrieves the instance with the specified service type and registration type.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the registry type is found.
+    func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service?
+
     /// Retrieves the instance with the specified service type and 1 argument to the factory closure.
     ///
     /// - Parameters:
@@ -57,6 +66,20 @@ public protocol Resolver {
         _ serviceType: Service.Type,
         name: String?,
         argument: Arg1) -> Service?
+
+    /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            1 argument and the registry type is found.
+    func resolve<Service, Arg1>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      argument: Arg1) -> Service?
 
     /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
     ///
@@ -84,6 +107,20 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2) -> Service?
 
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 2 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+
     /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -109,6 +146,20 @@ public protocol Resolver {
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 3 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
 
     /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
     ///
@@ -136,6 +187,20 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
 
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 4 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+
     /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -161,6 +226,20 @@ public protocol Resolver {
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 5 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
 
     /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
     ///
@@ -188,6 +267,20 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
 
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 6 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+
     /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -213,6 +306,20 @@ public protocol Resolver {
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 7 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
 
     /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
     ///
@@ -240,6 +347,20 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
 
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 8 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+
     /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
     ///
     /// - Parameters:
@@ -266,5 +387,19 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
 
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType:   The service type to resolve.
+    ///   - repsitoryType: The registration type.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 9 arguments and the registry type is found.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+      _ serviceType: Service.Type,
+      registryType: RegistryType,
+      arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
 
 }
+

--- a/Sources/SynchronizedResolver.Arguments.erb
+++ b/Sources/SynchronizedResolver.Arguments.erb
@@ -42,5 +42,16 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        <%= arg_param_def %>) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, <%= arg_param_name %>: <%= arg_param_call %>)
+        }
+    }
+
 <% end %>
 }
+

--- a/Sources/SynchronizedResolver.Arguments.swift
+++ b/Sources/SynchronizedResolver.Arguments.swift
@@ -36,6 +36,16 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, Arg1>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        argument: Arg1) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, argument: argument)
+        }
+    }
+
     internal func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2) -> Service?
@@ -52,6 +62,16 @@ extension SynchronizedResolver {
     {
         return container.lock.sync {
             return self.container.resolve(serviceType, name: name, arguments: arg1, arg2)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2)
         }
     }
 
@@ -74,6 +94,16 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3)
+        }
+    }
+
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
@@ -90,6 +120,16 @@ extension SynchronizedResolver {
     {
         return container.lock.sync {
             return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4)
         }
     }
 
@@ -112,6 +152,16 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5)
+        }
+    }
+
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
@@ -128,6 +178,16 @@ extension SynchronizedResolver {
     {
         return container.lock.sync {
             return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
         }
     }
 
@@ -150,6 +210,16 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+        }
+    }
+
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
@@ -166,6 +236,16 @@ extension SynchronizedResolver {
     {
         return container.lock.sync {
             return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
     }
 
@@ -188,4 +268,15 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        registryType: RegistryType,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+        }
+    }
+
 }
+

--- a/Sources/SynchronizedResolver.swift
+++ b/Sources/SynchronizedResolver.swift
@@ -39,4 +39,10 @@ extension SynchronizedResolver: Resolver {
             return self.container.resolve(serviceType, name: name)
         }
     }
+
+    internal func resolve<Service>(_ serviceType: Service.Type, registryType: RegistryType) -> Service? {
+        return container.lock.sync {
+            return self.container.resolve(serviceType, name: registryType.name)
+        }
+  	}
 }

--- a/Swinject.xcodeproj/SwinjectTests_Info.plist
+++ b/Swinject.xcodeproj/SwinjectTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Swinject.xcodeproj/Swinject_Info.plist
+++ b/Swinject.xcodeproj/Swinject_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6742CE561F459F6900F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE571F45A42E00F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE581F45A43300F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
+		6742CE591F45A43A00F6B648 /* RegistryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6742CE551F459F6900F6B648 /* RegistryType.swift */; };
 		90B029751C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
 		90B029761C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
 		90B029771C18599200A6A521 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B029741C18599200A6A521 /* Assembly.swift */; };
@@ -211,6 +215,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6742CE551F459F6900F6B648 /* RegistryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryType.swift; sourceTree = "<group>"; };
 		90B029741C18599200A6A521 /* Assembly.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembly.swift; sourceTree = "<group>"; };
 		90B029781C185B1600A6A521 /* Assembler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembler.swift; sourceTree = "<group>"; };
 		90B0297E1C18666200A6A521 /* AssemblerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssemblerSpec.swift; sourceTree = "<group>"; };
@@ -233,7 +238,7 @@
 		984774F41C02F4EA0092A757 /* SynchronizedResolver.Arguments.erb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SynchronizedResolver.Arguments.erb; sourceTree = "<group>"; };
 		984774F91C02F5A50092A757 /* SynchronizedResolver.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolver.Arguments.swift; sourceTree = "<group>"; };
 		984774FE1C034C5C0092A757 /* SynchronizedResolverSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolverSpec.swift; sourceTree = "<group>"; };
-		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; };
+		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9848611B1B6F9B7000C07072 /* ContainerSpec.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerSpec.Arguments.swift; sourceTree = "<group>"; };
 		984BE3121CDA3FCF00BCF2AC /* _Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Resolver.swift; sourceTree = "<group>"; };
 		984E8A511C317AC90039943D /* Swinject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swinject.h; sourceTree = "<group>"; };
@@ -419,6 +424,7 @@
 				CD3B32911DD6121500B208A3 /* InstanceStorage.swift */,
 				984BE3121CDA3FCF00BCF2AC /* _Resolver.swift */,
 				98B012C11B82F70A00053A32 /* Resolver.erb */,
+				6742CE551F459F6900F6B648 /* RegistryType.swift */,
 				983B98301C06ECB2006A23D4 /* SpinLock.swift */,
 				98E550C21DEF066300BE6304 /* UnavailableItems.swift */,
 				98B012BD1B82D6B000053A32 /* GeneratedCode */,
@@ -877,6 +883,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE571F45A42E00F6B648 /* RegistryType.swift in Sources */,
 				983B98321C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				985BAFAA1B625E0F0055F998 /* ServiceEntry.swift in Sources */,
 				CD3B32981DD6126E00B208A3 /* ObjectScope.Standard.swift in Sources */,
@@ -929,6 +936,7 @@
 				90B029791C185B1600A6A521 /* Assembler.swift in Sources */,
 				9880E70E1C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				CD3B32971DD6126E00B208A3 /* ObjectScope.Standard.swift in Sources */,
+				6742CE561F459F6900F6B648 /* RegistryType.swift in Sources */,
 				985BAFA91B625E0F0055F998 /* ServiceEntry.swift in Sources */,
 				984774F01C02F25D0092A757 /* SynchronizedResolver.swift in Sources */,
 				CD3C2CDF1D98E47000863421 /* DebugHelper.swift in Sources */,
@@ -974,6 +982,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE581F45A43300F6B648 /* RegistryType.swift in Sources */,
 				983B98331C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				9880E7101C09EE2900ED5293 /* FunctionType.swift in Sources */,
 				985011221BBE7E8900A2CCFC /* ObjectScope.swift in Sources */,
@@ -998,6 +1007,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6742CE591F45A43A00F6B648 /* RegistryType.swift in Sources */,
 				90B0297D1C185B2200A6A521 /* Assembly.swift in Sources */,
 				983B98341C06ECB2006A23D4 /* SpinLock.swift in Sources */,
 				9880E7111C09EE2900ED5293 /* FunctionType.swift in Sources */,

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-Package.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-Package.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Swinject::Swinject"
+               BuildableName = "Swinject.framework"
+               BlueprintName = "Swinject"
+               ReferencedContainer = "container:Swinject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Swinject::SwinjectTests"
+               BuildableName = "SwinjectTests.xctest"
+               BlueprintName = "SwinjectTests"
+               ReferencedContainer = "container:Swinject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Swinject::Swinject"
+            BuildableName = "Swinject.framework"
+            BlueprintName = "Swinject"
+            ReferencedContainer = "container:Swinject.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>SchemeUserState</key>
+  <dict>
+    <key>Swinject-Package.xcscheme</key>
+    <dict></dict>
+  </dict>
+  <key>SuppressBuildableAutocreation</key>
+  <dict></dict>
+</dict>
+</plist>


### PR DESCRIPTION
Add RegistryType to specify the registration without String.

## Motivation
In my opinion, specifying the registration from String is little fragile.
And I want to specify it by enum.

So, in my project, I write like below.

```swift
enum RegistrationType: String {
  case A
  case B
  
  var name: String {
    return rawValue
  }
}

let registration = container.resolve(Class.self, name: RegistrationType.A.name)
```

But, I do not want to write the `.name`, because that is a little wordy, then I create this pull request.


Best regards.