### PR TITLE
Remove superfluous swiftlint disable commands from tests

### DIFF
--- a/Tests/SwinjectTests/AssemblerSpec.swift
+++ b/Tests/SwinjectTests/AssemblerSpec.swift
@@ -5,7 +5,6 @@
 //  Created by mike.owens on 12/9/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Foundation

--- a/Tests/SwinjectTests/ContainerSpec.Arguments.swift
+++ b/Tests/SwinjectTests/ContainerSpec.Arguments.swift
@@ -5,7 +5,6 @@
 //  Created by Yoichi Tagaya on 8/3/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Quick

--- a/Tests/SwinjectTests/ContainerSpec.Circularity.swift
+++ b/Tests/SwinjectTests/ContainerSpec.Circularity.swift
@@ -5,7 +5,6 @@
 //  Created by Yoichi Tagaya on 7/29/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Quick

--- a/Tests/SwinjectTests/ContainerSpec.CustomScope.swift
+++ b/Tests/SwinjectTests/ContainerSpec.CustomScope.swift
@@ -5,7 +5,6 @@
 //  Created by Jakub Vaňo on 11/11/16.
 //  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Quick

--- a/Tests/SwinjectTests/ContainerSpec.CustomStringConvertible.swift
+++ b/Tests/SwinjectTests/ContainerSpec.CustomStringConvertible.swift
@@ -5,7 +5,6 @@
 //  Created by Jakub Vaňo on 13/06/2017.
 //  Copyright © 2017 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable line_length
 

--- a/Tests/SwinjectTests/ContainerSpec.DebugHelper.swift
+++ b/Tests/SwinjectTests/ContainerSpec.DebugHelper.swift
@@ -5,8 +5,6 @@
 //  Created by Jakub Vaňo on 26/09/16.
 //  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
-// swiftlint:disable function_body_length
 
 import Quick
 import Nimble

--- a/Tests/SwinjectTests/ServiceEntrySpec.swift
+++ b/Tests/SwinjectTests/ServiceEntrySpec.swift
@@ -5,8 +5,6 @@
 //  Created by Yoichi Tagaya on 7/29/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
-// swiftlint:disable function_body_length
 
 import Quick
 import Nimble

--- a/Tests/SwinjectTests/ServiceKeySpec.swift
+++ b/Tests/SwinjectTests/ServiceKeySpec.swift
@@ -5,7 +5,6 @@
 //  Created by Yoichi Tagaya on 7/23/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Quick

--- a/Tests/SwinjectTests/SynchronizedResolverSpec.swift
+++ b/Tests/SwinjectTests/SynchronizedResolverSpec.swift
@@ -5,7 +5,6 @@
 //  Created by Yoichi Tagaya on 11/23/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 
 import Dispatch

--- a/Tests/SwinjectTests/WeakStorageSpec.swift
+++ b/Tests/SwinjectTests/WeakStorageSpec.swift
@@ -5,8 +5,6 @@
 //  Created by Jakub Vaňo on 11/30/16.
 //  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable type_body_length
-// swiftlint:disable function_body_length
 
 import Quick
 import Nimble


### PR DESCRIPTION
Removes superfluous swiftlint disable commands from tests, which cause linting to fail with errors. Resolves #292.