### PR TITLE
Use hashValue from ObjectIdentifier instead of described String.

### DIFF
--- a/Sources/ServiceKey.swift
+++ b/Sources/ServiceKey.swift
@@ -30,7 +30,7 @@ internal struct ServiceKey {
 // MARK: Hashable
 extension ServiceKey: Hashable {
     var hashValue: Int {
-        return String(describing: factoryType).hashValue ^ (name?.hashValue ?? 0) ^ (option?.hashValue ?? 0)
+        return ObjectIdentifier(factoryType).hashValue ^ (name?.hashValue ?? 0) ^ (option?.hashValue ?? 0)
     }
 }
 


### PR DESCRIPTION
Hi there,
This pr is super [nits], ObjectIdentifier is usable when you wish hashValue from metatype or class value. I think its better than `String(describing:_)`.
ObjectIdentifier documents is here. https://developer.apple.com/documentation/swift/objectidentifier

If you don't wish to use feature around Reflecting, please close this pr.