### PR TITLE
Add possibility to specify default object scope to container

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -28,12 +28,14 @@ public final class Container {
     fileprivate let parent: Container? // Used by HierarchyObjectScope
     fileprivate var resolutionDepth = 0
     fileprivate let debugHelper: DebugHelper
+    fileprivate let defaultObjectScope: ObjectScope
     internal let lock: SpinLock // Used by SynchronizedResolver.
 
-    internal init(parent: Container? = nil, debugHelper: DebugHelper) {
+    internal init(parent: Container? = nil, debugHelper: DebugHelper, defaultObjectScope: ObjectScope = .graph) {
         self.parent = parent
         self.debugHelper = debugHelper
         self.lock = parent.map { $0.lock } ?? SpinLock()
+        self.defaultObjectScope = defaultObjectScope
     }
 
     /// Instantiates a `Container` with its parent `Container`. The parent is optional.
@@ -132,7 +134,7 @@ public final class Container {
         option: ServiceKeyOption? = nil
     ) -> ServiceEntry<Service> {
         let key = ServiceKey(factoryType: type(of: factory), name: name, option: option)
-        let entry = ServiceEntry(serviceType: serviceType, factory: factory)
+        let entry = ServiceEntry(serviceType: serviceType, factory: factory, objectScope: defaultObjectScope)
         services[key] = entry
         return entry
     }

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -32,6 +32,11 @@ public final class ServiceEntry<Service> {
         self.factory = factory
     }
 
+    convenience internal init(serviceType: Service.Type, factory: FunctionType, objectScope: ObjectScope) {
+      self.init(serviceType: serviceType, factory: factory)
+      self.objectScope = objectScope
+    }
+
     internal func copyExceptInstance() -> ServiceEntry<Service> {
         let copy = ServiceEntry(serviceType: serviceType, factory: factory)
         copy.objectScope = objectScope

--- a/Tests/SwinjectTests/ContainerSpec.swift
+++ b/Tests/SwinjectTests/ContainerSpec.swift
@@ -339,5 +339,13 @@ class ContainerSpec: QuickSpec {
                 expect(container.resolve(Animal.self) as? Cat).notTo(beNil())
             }
         }
+        describe("Default object scope") {
+            it("registers services with given object scope") {
+                let container = Container(parent: nil, debugHelper: LoggingDebugHelper(), defaultObjectScope: .weak)
+
+                let serviceEntry = container.register(Animal.self) { _ in Siamese(name: "Siam") }
+                expect(serviceEntry.objectScope) === ObjectScope.weak
+        }
     }
+}
 }

--- a/Tests/SwinjectTests/ServiceEntrySpec.swift
+++ b/Tests/SwinjectTests/ServiceEntrySpec.swift
@@ -16,5 +16,10 @@ class ServiceEntrySpec: QuickSpec {
             let entry = ServiceEntry(serviceType: Int.self, factory: { return 0 })
             expect(entry.objectScope) === ObjectScope.graph
         }
+
+        it("has ObjectScope set to value from init.") {
+            let entry = ServiceEntry(serviceType: Int.self, factory: { return 0 }, objectScope: .weak)
+            expect(entry.objectScope) === ObjectScope.weak
+        }
     }
 }


### PR DESCRIPTION
This allows you to specify the default object scope that the container uses to create the service entries. It is still defaulting to `.graph` to keep the behaviour equal.

This should also solve the issue mentioned here: https://github.com/Swinject/Swinject/issues/291