### PR TITLE
Prevent warning in Xcode 9.1

### DIFF
--- a/Sample-iOS.playground/Contents.swift
+++ b/Sample-iOS.playground/Contents.swift
@@ -231,11 +231,11 @@ container.register(Animal.self) { _, name, running in Horse(name: name, running:
 // If you pass an argument, pass it to `argument` parameter.
 // If you pass more arguments, pass them as a tuple to `arguments` parameter.
 let horse1 = container.resolve(Animal.self, argument: "Spirit") as! Horse
-print(horse1.name)
+print(horse1.name!)
 print(horse1.running)
 
 let horse2 = container.resolve(Animal.self, arguments: "Lucky", true) as! Horse
-print(horse2.name)
+print(horse2.name!)
 print(horse2.running)
 
 /*:

--- a/Sample-iOS.playground/timeline.xctimeline
+++ b/Sample-iOS.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -233,7 +233,7 @@
 		984774F41C02F4EA0092A757 /* SynchronizedResolver.Arguments.erb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SynchronizedResolver.Arguments.erb; sourceTree = "<group>"; };
 		984774F91C02F5A50092A757 /* SynchronizedResolver.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolver.Arguments.swift; sourceTree = "<group>"; };
 		984774FE1C034C5C0092A757 /* SynchronizedResolverSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedResolverSpec.swift; sourceTree = "<group>"; };
-		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; };
+		9848611A1B6F21EC00C07072 /* Sample-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Sample-iOS.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9848611B1B6F9B7000C07072 /* ContainerSpec.Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerSpec.Arguments.swift; sourceTree = "<group>"; };
 		984BE3121CDA3FCF00BCF2AC /* _Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Resolver.swift; sourceTree = "<group>"; };
 		984E8A511C317AC90039943D /* Swinject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swinject.h; sourceTree = "<group>"; };


### PR DESCRIPTION
Error stated ‘Expression explicitly coerced from String? to Any’; force-unwrapping resolves this.

<img width="957" alt="swinject warning" src="https://user-images.githubusercontent.com/337963/33244473-d2da8668-d2c5-11e7-8a39-1c73c7725932.png">
