### PR TITLE
Weak in circular dependency

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -199,7 +199,7 @@ extension Container: _Resolver {
 
         resolutionDepth -= 1
         if resolutionDepth == 0 {
-            resetObjectScope(.graph)
+            services.values.forEach { $0.storage.graphResolutionCompleted() }
         }
     }
 }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -63,13 +63,13 @@ public final class Container {
         services.removeAll()
     }
 
-    /// Discards instances for services registered in the given `ObjectsScopeType`.
+    /// Discards instances for services registered in the given `ObjectsScopeProtocol`.
     ///
     /// **Example usage:**
     ///     container.resetObjectScope(ObjectScope.container)
     ///
     /// - Parameters:
-    ///     - objectScope: All instances registered in given `ObjectsScopeType` will be discarded.
+    ///     - objectScope: All instances registered in given `ObjectsScopeProtocol` will be discarded.
     public func resetObjectScope(_ objectScope: ObjectScopeProtocol) {
         services.values
             .filter { $0.objectScope === objectScope }

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -9,6 +9,21 @@
 /// Storage provided by `ObjectScope`. It is used by `Container` to persist resolved instances.
 public protocol InstanceStorage: AnyObject {
     var instance: Any? { get set }
+    func graphResolutionCompleted()
+}
+
+extension InstanceStorage {
+    public func graphResolutionCompleted() {}
+}
+
+public final class GraphStorage: InstanceStorage {
+    public var instance: Any?
+
+    public init() {}
+
+    public func graphResolutionCompleted() {
+        instance = nil
+    }
 }
 
 /// Persists stored instance until it is explicitly discarded.

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -16,6 +16,7 @@ extension InstanceStorage {
     public func graphResolutionCompleted() {}
 }
 
+/// Persists storage during the resolution of the object graph
 public final class GraphStorage: InstanceStorage {
     public var instance: Any?
 
@@ -63,6 +64,8 @@ public final class WeakStorage: InstanceStorage {
     public init () {}
 }
 
+/// Combines the behavior of multiple instance storages.
+/// Instance is persisted as long as at least one of the underlying storages is persisting it.
 public final class CompositeStorage: InstanceStorage {
     private let components: [InstanceStorage]
 

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -62,3 +62,20 @@ public final class WeakStorage: InstanceStorage {
 
     public init () {}
 }
+
+public final class CompositeStorage: InstanceStorage {
+    private let components: [InstanceStorage]
+
+    public var instance: Any? {
+        get { return components.flatMap { $0.instance } .first }
+        set { components.forEach { $0.instance = newValue } }
+    }
+
+    public init(_ components: [InstanceStorage]) {
+        self.components = components
+    }
+
+    public func graphResolutionCompleted() {
+        components.forEach { $0.graphResolutionCompleted() }
+    }
+}

--- a/Sources/ObjectScope.Standard.swift
+++ b/Sources/ObjectScope.Standard.swift
@@ -13,7 +13,7 @@ extension ObjectScope {
 
     /// Instances are shared only when an object graph is being created,
     /// otherwise a new instance is created by the `Container`. This is the default scope.
-    public static let graph = ObjectScope(storageFactory: PermanentStorage.init, description: "graph")
+    public static let graph = ObjectScope(storageFactory: GraphStorage.init, description: "graph")
 
     /// An instance provided by the `Container` is shared within the `Container` and its child `Containers`.
     public static let container = ObjectScope(storageFactory: PermanentStorage.init, description: "container")

--- a/Sources/ObjectScope.Standard.swift
+++ b/Sources/ObjectScope.Standard.swift
@@ -21,5 +21,6 @@ extension ObjectScope {
     /// An instance provided by the `Container` is shared within the `Container` and its child `Container`s 
     /// as long as there are strong references to given instance. Otherwise new instance is created
     /// when resolving the type.
-    public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak", parent: ObjectScope.graph)
+    public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak",
+                                         parent: ObjectScope.graph)
 }

--- a/Sources/ObjectScope.Standard.swift
+++ b/Sources/ObjectScope.Standard.swift
@@ -21,5 +21,5 @@ extension ObjectScope {
     /// An instance provided by the `Container` is shared within the `Container` and its child `Container`s 
     /// as long as there are strong references to given instance. Otherwise new instance is created
     /// when resolving the type.
-    public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak")
+    public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak", parent: ObjectScope.graph)
 }

--- a/Sources/ObjectScope.swift
+++ b/Sources/ObjectScope.swift
@@ -20,6 +20,7 @@ public class ObjectScope: ObjectScopeProtocol, CustomStringConvertible {
 
     public private(set) var description: String
     private var storageFactory: () -> InstanceStorage
+    private let parent: ObjectScopeProtocol?
 
     /// Instantiates an `ObjectScope` with storage factory and description.
     ///  - Parameters:
@@ -27,14 +28,20 @@ public class ObjectScope: ObjectScopeProtocol, CustomStringConvertible {
     ///     - description:      Description of object scope for `CustomStringConvertible` implementation
     public init(
         storageFactory: @escaping () -> InstanceStorage,
-        description: String = ""
+        description: String = "",
+        parent: ObjectScopeProtocol? = nil
     ) {
         self.storageFactory = storageFactory
         self.description = description
+        self.parent = parent
     }
 
     /// Will invoke and return the result of `storageFactory` closure provided during initialisation.
     public func makeStorage() -> InstanceStorage {
-        return storageFactory()
+        if let parent = parent {
+            return CompositeStorage([storageFactory(), parent.makeStorage()])
+        } else {
+            return storageFactory()
+        }
     }
 }

--- a/Sources/ObjectScope.swift
+++ b/Sources/ObjectScope.swift
@@ -26,6 +26,7 @@ public class ObjectScope: ObjectScopeProtocol, CustomStringConvertible {
     ///  - Parameters:
     ///     - storageFactory:   Closure for creating an `InstanceStorage`
     ///     - description:      Description of object scope for `CustomStringConvertible` implementation
+    ///     - parent:           If provided, its storage will be composed with the result of `storageFactory`
     public init(
         storageFactory: @escaping () -> InstanceStorage,
         description: String = "",

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -37,13 +37,6 @@ public final class ServiceEntry<Service> {
       self.objectScope = objectScope
     }
 
-    internal func copyExceptInstance() -> ServiceEntry<Service> {
-        let copy = ServiceEntry(serviceType: serviceType, factory: factory)
-        copy.objectScope = objectScope
-        copy.initCompleted = initCompleted
-        return copy
-    }
-
     /// Specifies the object scope to resolve the service.
     ///
     /// - Parameter scope: The `ObjectScopeProtocol` value.

--- a/Tests/SwinjectTests/Circularity.swift
+++ b/Tests/SwinjectTests/Circularity.swift
@@ -71,3 +71,7 @@ internal class DDependingOnBC: D {
     weak var b: B?
     weak var c: C?
 }
+
+internal class CDependingOnWeakB: C {
+    weak var b: B?
+}


### PR DESCRIPTION
Resolves #302.

This introduces concept of **Object scope hierarchy** - i.e. object scope can have a parent scope, which means that instances will be persisted either by its own or its parent `InstanceStorage`s.

Related to object scope hierarchy is the change of how the instances in `ObjectScope.graph` are discarded after the object graph is resolved.

All those changes should be backwards compatible.