### PR TITLE
Fix README for swift 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Services should be registered in an extension of `SwinjectStoryboard` if you use
 
 ```swift
 extension SwinjectStoryboard {
-    class func setup() {
+    @objc class func setup() {
         defaultContainer.register(Animal.self) { _ in Cat(name: "Mimi") }
         defaultContainer.register(Person.self) { r in
             PetOwner(pet: r.resolve(Animal.self)!)


### PR DESCRIPTION
@objc attribute is mandatory for SwinjectStoryboard's setup() class
function in swift 4.
see https://github.com/Swinject/SwinjectStoryboard#uiwindow-and-root-view-controller-instantiation
for more details.