### PR TITLE
Update the project for Xcode 9.3 and Swift 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode9.3beta
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: JOB="POD_LINT"
       script:
         - pod lib lint
-    - env: JOB="XCODE" DEST="OS=8.4,name=iPhone 5" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test"
+    # - env: JOB="XCODE" DEST="OS=8.4,name=iPhone 5" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test"
     - env: JOB="XCODE" DEST="OS=9.3,name=iPhone 6" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test"
     - env: JOB="XCODE" DEST="OS=10.3.1,name=iPhone 7 Plus" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test"
     - env: JOB="XCODE" DEST="OS=11.2,name=iPhone 8 Plus" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test"

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -277,8 +277,7 @@ extension Container: Resolver {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type and name 
     ///            is found in the `Container`.
     public func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service? {
-        typealias FactoryType = (Resolver) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory(self) }
+        return _resolve(name: name) { (factory: (Resolver) -> Any) in factory(self) }
     }
 
     fileprivate func getEntry(for key: ServiceKey) -> ServiceEntryProtocol? {

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -79,7 +79,7 @@ public final class CompositeStorage: InstanceStorage {
     private let components: [InstanceStorage]
 
     public var instance: Any? {
-        get { return components.flatMap { $0.instance } .first }
+        get { return components.compactMap { $0.instance } .first }
         set { components.forEach { $0.instance = newValue } }
     }
 
@@ -96,7 +96,7 @@ public final class CompositeStorage: InstanceStorage {
     }
 
     public func instance(inGraph graph: GraphIdentifier) -> Any? {
-        return components.flatMap { $0.instance(inGraph: graph) } .first
+        return components.compactMap { $0.instance(inGraph: graph) } .first
     }
 }
 

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -79,7 +79,13 @@ public final class CompositeStorage: InstanceStorage {
     private let components: [InstanceStorage]
 
     public var instance: Any? {
-        get { return components.compactMap { $0.instance } .first }
+        get {
+            #if swift(>=4.1)
+                return components.compactMap { $0.instance } .first
+            #else
+                return components.flatMap { $0.instance } .first
+            #endif
+        }
         set { components.forEach { $0.instance = newValue } }
     }
 
@@ -96,7 +102,11 @@ public final class CompositeStorage: InstanceStorage {
     }
 
     public func instance(inGraph graph: GraphIdentifier) -> Any? {
-        return components.compactMap { $0.instance(inGraph: graph) } .first
+        #if swift(>=4.1)
+            return components.compactMap { $0.instance(inGraph: graph) } .first
+        #else
+            return components.flatMap { $0.instance(inGraph: graph) } .first
+        #endif
     }
 }
 

--- a/Sources/InstanceWrapper.swift
+++ b/Sources/InstanceWrapper.swift
@@ -79,11 +79,3 @@ extension Optional: InstanceWrapper {
         self = factory?() as? Wrapped
     }
 }
-
-extension ImplicitlyUnwrappedOptional: InstanceWrapper {
-    static var wrappedType: Any.Type { return Wrapped.self }
-
-    init?(inContainer container: Container, withInstanceFactory factory: (() -> Any?)?) {
-        self = factory?() as? Wrapped
-    }
-}

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -139,6 +139,10 @@
 		CD6A9F821EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6A9F811EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift */; };
 		CD6A9F831EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6A9F811EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift */; };
 		CD6A9F841EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6A9F811EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift */; };
+		CD89E3472036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
+		CD89E3492036F2BE00A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
+		CD89E34A2036F2BF00A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
+		CD89E34B2036F2C000A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
 		CD89E34D2037016700A9ED33 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E34C2037016700A9ED33 /* Behavior.swift */; };
 		CD89E34E20371C0100A9ED33 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E34C2037016700A9ED33 /* Behavior.swift */; };
 		CD89E34F20371C0200A9ED33 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E34C2037016700A9ED33 /* Behavior.swift */; };
@@ -146,16 +150,12 @@
 		CD89E35220371D7900A9ED33 /* ContainerSpec.Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E35120371D7900A9ED33 /* ContainerSpec.Behavior.swift */; };
 		CD89E35320371D7900A9ED33 /* ContainerSpec.Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E35120371D7900A9ED33 /* ContainerSpec.Behavior.swift */; };
 		CD89E35420371D7900A9ED33 /* ContainerSpec.Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E35120371D7900A9ED33 /* ContainerSpec.Behavior.swift */; };
-		CDB19E52204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
-		CDB19E53204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
-		CDB19E54204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
-		CD89E3472036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
-		CD89E3492036F2BE00A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
-		CD89E34A2036F2BF00A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
-		CD89E34B2036F2C000A9ED33 /* ServiceEntry.TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */; };
 		CD8E362C20595ACD00F2A5CF /* ProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8E362B20595ACD00F2A5CF /* ProviderSpec.swift */; };
 		CD8E362D20595ACD00F2A5CF /* ProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8E362B20595ACD00F2A5CF /* ProviderSpec.swift */; };
 		CD8E362E20595ACD00F2A5CF /* ProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8E362B20595ACD00F2A5CF /* ProviderSpec.swift */; };
+		CDB19E52204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
+		CDB19E53204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
+		CDB19E54204ED97400D67123 /* BehaviorFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB19E51204ED97400D67123 /* BehaviorFakes.swift */; };
 		CDBBACF61D9EAD60002F5EF9 /* Container.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBBACF51D9EAD60002F5EF9 /* Container.Logging.swift */; };
 		CDBBACF71D9EAD60002F5EF9 /* Container.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBBACF51D9EAD60002F5EF9 /* Container.Logging.swift */; };
 		CDBBACF81D9EAD60002F5EF9 /* Container.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBBACF51D9EAD60002F5EF9 /* Container.Logging.swift */; };
@@ -329,12 +329,12 @@
 		CD5E9A3520515898009090F9 /* GraphIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphIdentifier.swift; sourceTree = "<group>"; };
 		CD65F048205943D400FB43EE /* EmploymentAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmploymentAssembly.swift; sourceTree = "<group>"; };
 		CD6A9F811EEFCB7A0087E851 /* ContainerSpec.CustomStringConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerSpec.CustomStringConvertible.swift; sourceTree = "<group>"; };
-		CD89E34C2037016700A9ED33 /* Behavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
-		CD89E35120371D7900A9ED33 /* ContainerSpec.Behavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.Behavior.swift; sourceTree = "<group>"; };
-		CDB19E51204ED97400D67123 /* BehaviorFakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorFakes.swift; sourceTree = "<group>"; };
 		CD89E3462036F28300A9ED33 /* ServiceEntry.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEntry.TypeForwarding.swift; sourceTree = "<group>"; };
 		CD89E3482036F2A800A9ED33 /* ServiceEntry.TypeForwarding.erb */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = ServiceEntry.TypeForwarding.erb; sourceTree = "<group>"; };
+		CD89E34C2037016700A9ED33 /* Behavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
+		CD89E35120371D7900A9ED33 /* ContainerSpec.Behavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.Behavior.swift; sourceTree = "<group>"; };
 		CD8E362B20595ACD00F2A5CF /* ProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderSpec.swift; sourceTree = "<group>"; };
+		CDB19E51204ED97400D67123 /* BehaviorFakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorFakes.swift; sourceTree = "<group>"; };
 		CDBBACF51D9EAD60002F5EF9 /* Container.Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.Logging.swift; sourceTree = "<group>"; };
 		CDBD0E672035EDF20030F566 /* ContainerSpec.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.TypeForwarding.swift; sourceTree = "<group>"; };
 		CDBD0E6B2035EEBB0030F566 /* Container.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.TypeForwarding.swift; sourceTree = "<group>"; };
@@ -805,7 +805,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Swinject Contributors";
 				TargetAttributes = {
 					981899BB1B5FE63F00C702D0 = {
@@ -1260,6 +1260,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;

--- a/Swinject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Swinject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Tests/SwinjectTests/ContainerSpec.Arguments.swift
+++ b/Tests/SwinjectTests/ContainerSpec.Arguments.swift
@@ -5,7 +5,7 @@
 //  Created by Yoichi Tagaya on 8/3/15.
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
-// swiftlint:disable function_body_length
+// swiftlint:disable function_body_length line_length
 
 import Quick
 import Nimble
@@ -55,7 +55,7 @@ class ContainerSpec_Arguments: QuickSpec {
             expect(animal?.name) == "1234"
         }
         it("accepts 5 arguments.") {
-            container.register(Animal.self) { _, arg1, arg2, arg3, arg4, arg5 in
+            container.register(Animal.self) { (_, arg1: String, arg2: String, arg3: String, arg4: String, arg5: String) in
                 Cat(name: arg1 + arg2 + arg3 + arg4 + arg5)
             }
             let animal = container.resolve(
@@ -64,7 +64,7 @@ class ContainerSpec_Arguments: QuickSpec {
             expect(animal?.name) == "12345"
         }
         it("accepts 6 arguments.") {
-            container.register(Animal.self) { _, arg1, arg2, arg3, arg4, arg5, arg6 in
+            container.register(Animal.self) { (_, arg1: String, arg2: String, arg3: String, arg4: String, arg5: String, arg6: String) in
                 Cat(name: arg1 + arg2 + arg3 + arg4 + arg5 + arg6)
             }
             let animal = container.resolve(
@@ -73,7 +73,7 @@ class ContainerSpec_Arguments: QuickSpec {
             expect(animal?.name) == "123456"
         }
         it("accepts 7 arguments.") {
-            container.register(Animal.self) { _, arg1, arg2, arg3, arg4, arg5, arg6, arg7 in
+            container.register(Animal.self) { (_, arg1: String, arg2: String, arg3: String, arg4: String, arg5: String, arg6: String, arg7: String) in
                 Cat(name: arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7)
             }
             let animal = container.resolve(
@@ -82,7 +82,7 @@ class ContainerSpec_Arguments: QuickSpec {
             expect(animal?.name) == "1234567"
         }
         it("accepts 8 arguments.") {
-            container.register(Animal.self) { _, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 in
+            container.register(Animal.self) { (_, arg1: String, arg2: String, arg3: String, arg4: String, arg5: String, arg6: String, arg7: String, arg8: String) in
                 Cat(name: arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8)
             }
             let animal = container.resolve(
@@ -91,7 +91,7 @@ class ContainerSpec_Arguments: QuickSpec {
             expect(animal?.name) == "12345678"
         }
         it("accepts 9 arguments.") {
-            container.register(Animal.self) { _, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 in
+            container.register(Animal.self) { (_, arg1: String, arg2: String, arg3: String, arg4: String, arg5: String, arg6: String, arg7: String, arg8: String, arg9: String) in
                 Cat(name: arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9)
             }
             let animal = container.resolve(

--- a/Tests/SwinjectTests/ContainerSpec.TypeForwarding.swift
+++ b/Tests/SwinjectTests/ContainerSpec.TypeForwarding.swift
@@ -129,27 +129,27 @@ class ContainerSpec_TypeForwarding: QuickSpec {
             it("resolves optional when wrapped type is registered") {
                 container.register(Dog.self) { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self)
-                let unwrappedDog = container.resolve(Dog!.self)
+                let unwrappedDog = container.resolve(Dog?.self)
                 expect(optionalDog ?? nil).notTo(beNil())
                 expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional to nil when wrapped type is not registered") {
                 let optionalDog = container.resolve(Dog?.self)
-                let unwrappedDog = container.resolve(Dog!.self)
+                let unwrappedDog = container.resolve(Dog?.self)
                 expect(optionalDog).notTo(beNil())
                 expect(unwrappedDog).notTo(beNil())
             }
             it("resolves optional with name") {
                 container.register(Dog.self, name: "Hachi") { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self, name: "Hachi")
-                let unwrappedDog = container.resolve(Dog!.self, name: "Hachi")
+                let unwrappedDog = container.resolve(Dog?.self, name: "Hachi")
                 expect(optionalDog ?? nil).notTo(beNil())
                 expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional to nil with wrong name") {
                 container.register(Dog.self, name: "Hachi") { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self, name: "Mimi")
-                let unwrappedDog = container.resolve(Dog!.self, name: "Mimi")
+                let unwrappedDog = container.resolve(Dog?.self, name: "Mimi")
                 expect(optionalDog ?? nil).to(beNil())
                 expect(unwrappedDog ?? nil).to(beNil())
                 expect(optionalDog).notTo(beNil())
@@ -158,14 +158,14 @@ class ContainerSpec_TypeForwarding: QuickSpec {
             it("resolves optional with arguments") {
                 container.register(Dog.self) { _, name in Dog(name: name) }
                 let optionalDog = container.resolve(Dog?.self, argument: "Hachi")
-                let unwrappedDog = container.resolve(Dog!.self, argument: "Hachi")
+                let unwrappedDog = container.resolve(Dog?.self, argument: "Hachi")
                 expect(optionalDog ?? nil).notTo(beNil())
                 expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional of fowrarded type") {
                 container.register(Dog.self) { _ in Dog() }.implements(Animal.self)
                 let optionalAnimal = container.resolve(Animal?.self)
-                let unwrappedAnimal = container.resolve(Animal!.self)
+                let unwrappedAnimal = container.resolve(Animal?.self)
                 expect(optionalAnimal ?? nil).notTo(beNil())
                 expect(unwrappedAnimal ?? nil).notTo(beNil())
             }

--- a/Tests/SwinjectTests/ContainerSpec.TypeForwarding.swift
+++ b/Tests/SwinjectTests/ContainerSpec.TypeForwarding.swift
@@ -129,38 +129,27 @@ class ContainerSpec_TypeForwarding: QuickSpec {
             it("resolves optional when wrapped type is registered") {
                 container.register(Dog.self) { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self)
-                let unwrappedDog = container.resolve(Dog?.self)
                 expect(optionalDog ?? nil).notTo(beNil())
-                expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional to nil when wrapped type is not registered") {
                 let optionalDog = container.resolve(Dog?.self)
-                let unwrappedDog = container.resolve(Dog?.self)
                 expect(optionalDog).notTo(beNil())
-                expect(unwrappedDog).notTo(beNil())
             }
             it("resolves optional with name") {
                 container.register(Dog.self, name: "Hachi") { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self, name: "Hachi")
-                let unwrappedDog = container.resolve(Dog?.self, name: "Hachi")
                 expect(optionalDog ?? nil).notTo(beNil())
-                expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional to nil with wrong name") {
                 container.register(Dog.self, name: "Hachi") { _ in Dog() }
                 let optionalDog = container.resolve(Dog?.self, name: "Mimi")
-                let unwrappedDog = container.resolve(Dog?.self, name: "Mimi")
                 expect(optionalDog ?? nil).to(beNil())
-                expect(unwrappedDog ?? nil).to(beNil())
                 expect(optionalDog).notTo(beNil())
-                expect(unwrappedDog).notTo(beNil())
             }
             it("resolves optional with arguments") {
                 container.register(Dog.self) { _, name in Dog(name: name) }
                 let optionalDog = container.resolve(Dog?.self, argument: "Hachi")
-                let unwrappedDog = container.resolve(Dog?.self, argument: "Hachi")
                 expect(optionalDog ?? nil).notTo(beNil())
-                expect(unwrappedDog ?? nil).notTo(beNil())
             }
             it("resolves optional of fowrarded type") {
                 container.register(Dog.self) { _ in Dog() }.implements(Animal.self)


### PR DESCRIPTION
Hi guys, below are the list of changes in the project:

• Update the **.travis.yml** to run on the Xcode9.3beta version.
• Replace the deprecated `flatMap` operator in favor of `compactMap`.
• Fix a lint warning with nesting type.
• Remove unnecessary implementation of the `InstanceWrapper ` by the `ImplicitlyUnwrappedOptional`.
• Fix an issue causing the compiler was not inferring the types for the `+` operator correctly declaring the types explicitly for the closure.
• Disable the `line_length` rule in the **ContainerSpec.Arguments** file to avoid the warnings.

Regarding the `+` operator problem with the Swift compiler I solve it in one of the several ways, we can solve it (explicitly declaring the types of the arguments in the closure, as the most of the times in type inference problems of the compiler). The `joined` function can be another solution as pointed by Rob Napier [here](https://stackoverflow.com/questions/39490808/how-to-merge-multiple-arrays-without-slowing-the-compiler-down/39511195#39511195).