### PR TITLE
Container as a Protocol to fascilitate mocking

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,8 @@
 disabled_rules:
   - force_cast
   - type_name
+  - identifier_name
+  - trailing_whitespace
 excluded:
   - Sources/Container.Arguments.swift
   - Sources/SynchronizedResolver.Arguments.swift

--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -44,7 +44,7 @@ public final class Assembler {
     /// - parameter container:          the baseline container
     ///
     @available(*, deprecated, message: "Use not throwing alternative: init(_:, container:)")
-    public convenience init(assemblies: [Assembly], container: Container? = Container()) throws {
+    public convenience init(assemblies: [Assembly], container: ContainerProtocol? = Container()) throws {
         if let container = container {
             self.init(assemblies, container: container)
         } else {
@@ -57,7 +57,7 @@ public final class Assembler {
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter container:          the baseline container
     ///
-    public init(_ assemblies: [Assembly], container: Container = Container()) {
+    public init(_ assemblies: [Assembly], container: ContainerProtocol = Container()) {
         self.container = container
         run(assemblies: assemblies)
     }

--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -10,7 +10,7 @@
 public final class Assembler {
 
     /// the container that each assembly will build its `Service` definitions into
-    private let container: Container
+    private let container: ContainerProtocol
 
     /// expose the container as a resolver so `Service` registration only happens within an assembly
     public var resolver: Resolver {
@@ -21,7 +21,7 @@ public final class Assembler {
     ///
     /// - parameter container: the baseline container
     ///
-    public init(container: Container? = Container()) {
+    public init(container: ContainerProtocol? = Container()) {
         self.container = container!
     }
 

--- a/Sources/Assembly.swift
+++ b/Sources/Assembly.swift
@@ -15,7 +15,7 @@ public protocol Assembly {
     ///
     /// - parameter container: the container provided by the `Assembler`
     ///
-    func assemble(container: Container)
+    func assemble(container: ContainerProtocol)
 
     /// Provides a hook to the `Assembly` that will be called once the `Assembler` has loaded all `Assembly`
     /// instances into the container.

--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -43,6 +43,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, <%= arg_types %>>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, <%= arg_types %>) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
 <% end %>
 }

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -39,6 +39,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, Arg1>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -59,6 +67,14 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -81,6 +97,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -101,6 +125,14 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -123,6 +155,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -143,6 +183,14 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -165,6 +213,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -186,6 +242,14 @@ extension Container {
     {
         return _register(serviceType, factory: factory, name: name)
     }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
+    }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -206,6 +270,14 @@ extension Container {
         factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service) -> ServiceEntry<Service>
     {
         return _register(serviceType, factory: factory, name: name)
+    }
+    
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+    _ serviceType: Service.Type,
+    factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service) -> ServiceEntry<Service>
+    {
+        return _register(serviceType, factory: factory, name: nil)
     }
 
 }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -26,7 +26,7 @@ import Foundation
 public final class Container: ContainerProtocol {
     
     internal var services = [ServiceKey: ServiceEntryProtocol]()
-    fileprivate let parent: Container? // Used by HierarchyObjectScope
+    fileprivate let parent: ContainerProtocol? // Used by HierarchyObjectScope
     fileprivate var resolutionDepth = 0
     fileprivate let debugHelper: DebugHelper
     fileprivate let defaultObjectScope: ObjectScope
@@ -35,7 +35,7 @@ public final class Container: ContainerProtocol {
     internal var behaviors = [Behavior]()
 
     internal init(
-        parent: Container? = nil,
+        parent: ContainerProtocol? = nil,
         debugHelper: DebugHelper,
         defaultObjectScope: ObjectScope = .graph) {
         self.parent = parent
@@ -55,7 +55,7 @@ public final class Container: ContainerProtocol {
     /// - Remark: Compile time may be long if you pass a long closure to this initializer.
     ///           Use `init()` or `init(parent:)` instead.
     public convenience init(
-        parent: Container? = nil,
+        parent: ContainerProtocol? = nil,
         defaultObjectScope: ObjectScope = .graph,
         behaviors: [Behavior] = [],
         registeringClosure: (Container) -> Void = { _ in }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -23,7 +23,7 @@ import Foundation
 ///
 /// where `A` and `X` are protocols, `B` is a type conforming `A`, and `Y` is a type conforming `X` 
 /// and depending on `A`.
-public final class Container {
+public final class Container: ContainerProtocol {
     internal var services = [ServiceKey: ServiceEntryProtocol]()
     fileprivate let parent: Container? // Used by HierarchyObjectScope
     fileprivate var resolutionDepth = 0

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -25,13 +25,14 @@ import Foundation
 /// and depending on `A`.
 public final class Container: ContainerProtocol {
     
+    public let lock: SpinLock // Used by SynchronizedResolver.
+
     internal var services = [ServiceKey: ServiceEntryProtocol]()
     fileprivate let parent: ContainerProtocol? // Used by HierarchyObjectScope
     fileprivate var resolutionDepth = 0
     fileprivate let debugHelper: DebugHelper
     fileprivate let defaultObjectScope: ObjectScope
     internal var currentObjectGraph: GraphIdentifier?
-    internal let lock: SpinLock // Used by SynchronizedResolver.
     internal var behaviors = [Behavior]()
 
     internal init(
@@ -236,7 +237,7 @@ extension Container: _Resolver {
         }
     }
 
-    fileprivate func getRegistrations() -> [ServiceKey: ServiceEntryProtocol] {
+    public func getRegistrations() -> [ServiceKey: ServiceEntryProtocol] {
         var registrations = parent?.getRegistrations() ?? [:]
         services.forEach { key, value in registrations[key] = value }
         return registrations
@@ -290,7 +291,7 @@ extension Container: Resolver {
         return _resolve(name: name) { (factory: (Resolver) -> Any) in factory(self) }
     }
 
-    fileprivate func getEntry(for key: ServiceKey) -> ServiceEntryProtocol? {
+    public func getEntry(for key: ServiceKey) -> ServiceEntryProtocol? {
         if let entry = services[key] {
             return entry
         } else {

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -24,6 +24,7 @@ import Foundation
 /// where `A` and `X` are protocols, `B` is a type conforming `A`, and `Y` is a type conforming `X` 
 /// and depending on `A`.
 public final class Container: ContainerProtocol {
+    
     internal var services = [ServiceKey: ServiceEntryProtocol]()
     fileprivate let parent: Container? // Used by HierarchyObjectScope
     fileprivate var resolutionDepth = 0
@@ -112,10 +113,19 @@ public final class Container: ContainerProtocol {
     @discardableResult
     public func register<Service>(
         _ serviceType: Service.Type,
-        name: String? = nil,
+        name: String?,
         factory: @escaping (Resolver) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
+    }
+    
+    /// Duplicate to conform to protocol
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        factory: @escaping (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: nil, factory: factory)
     }
 
     /// This method is designed for the use to extend Swinject functionality.

--- a/Sources/ContainerProtocol.swift
+++ b/Sources/ContainerProtocol.swift
@@ -8,7 +8,15 @@
 
 import Foundation
 
-public protocol ContainerProtocol {
+/// These are functions made public so we can have a ContainerProtocol instead of a final class.
+public protocol ServiceGetterProtocol {
+    func getRegistrations() -> [ServiceKey: ServiceEntryProtocol]
+    func getEntry(for key: ServiceKey) -> ServiceEntryProtocol?
+}
+
+public protocol ContainerProtocol: Resolver, ServiceGetterProtocol {
+    var lock: SpinLock { get }
+    
     func removeAll()
     /// Discards instances for services registered in the given `ObjectsScopeProtocol`.
     ///

--- a/Sources/ContainerProtocol.swift
+++ b/Sources/ContainerProtocol.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-/// These are functions made public so we can have a ContainerProtocol instead of a final class.
+/// These are functions made so we can have a ContainerProtocol instead of a final class.
 public protocol ServiceGetterProtocol {
     func getRegistrations() -> [ServiceKey: ServiceEntryProtocol]
     func getEntry(for key: ServiceKey) -> ServiceEntryProtocol?
 }
 
-public protocol ContainerProtocol: Resolver, ServiceGetterProtocol {
+public protocol ContainerProtocol: Resolver, ServiceGetterProtocol, ContainerArgumentable {
     var lock: SpinLock { get }
     
     func removeAll()
@@ -96,4 +96,74 @@ public protocol ContainerProtocol: Resolver, ServiceGetterProtocol {
     /// - Parameters:
     ///     - behavior: Behavior to be added to the container
     func addBehavior(_ behavior: Behavior)
+}
+
+/// Manualy added this, should be done by a script script/gencode but had no time to that
+public protocol ContainerArgumentable {
+    
+    @discardableResult
+    func register<Service, Arg1>(
+        _ serviceType: Service.Type,
+        name: String?,
+        factory: @escaping (Resolver, Arg1) -> Service) -> ServiceEntry<Service>
+
+    @discardableResult
+    func register<Service, Arg1>(
+        _ serviceType: Service.Type,
+        factory: @escaping (Resolver, Arg1) -> Service) -> ServiceEntry<Service>
+
+    @discardableResult
+    func register<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        name: String?,
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
+
+    @discardableResult
+    func register<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
+
+    @discardableResult
+    func register<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        name: String?,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service) -> ServiceEntry<Service>
+    
+    @discardableResult
+    func register<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service) -> ServiceEntry<Service>
+    
+    // MARK: - Resolver with Arguments
+        func resolve<Service, Arg1>(
+            _ serviceType: Service.Type,
+            argument: Arg1) -> Service?
+ 
+        func resolve<Service, Arg1>(
+            _ serviceType: Service.Type,
+            name: String?,
+            argument: Arg1) -> Service?
+ 
+        func resolve<Service, Arg1, Arg2>(
+            _ serviceType: Service.Type,
+            arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+
+        func resolve<Service, Arg1, Arg2>(
+            _ serviceType: Service.Type,
+            name: String?,
+            arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+
+        func resolve<Service, Arg1, Arg2, Arg3>(
+            _ serviceType: Service.Type,
+            arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+
+        func resolve<Service, Arg1, Arg2, Arg3>(
+            _ serviceType: Service.Type,
+            name: String?,
+            arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+
+        func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+            _ serviceType: Service.Type,
+            arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    
 }

--- a/Sources/ContainerProtocol.swift
+++ b/Sources/ContainerProtocol.swift
@@ -1,0 +1,76 @@
+//
+//  ContainerProtocol.swift
+//  Swinject
+//
+//  Created by Stijn on 16/05/2018.
+//  Copyright © 2018 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public protocol ContainerProtocol {
+    func removeAll()
+
+    /// Discards instances for services registered in the given `ObjectsScopeProtocol`.
+    ///
+    /// **Example usage:**
+    ///     container.resetObjectScope(ObjectScope.container)
+    ///
+    /// - Parameters:
+    ///     - objectScope: All instances registered in given `ObjectsScopeProtocol` will be discarded.
+    func resetObjectScope(_ objectScope: ObjectScopeProtocol)
+
+    /// Discards instances for services registered in the given `ObjectsScope`. It performs the same operation
+    /// as `resetObjectScope(_:ObjectScopeProtocol)`, but provides more convenient usage syntax.
+    ///
+    /// **Example usage:**
+    ///     container.resetObjectScope(.container)
+    ///
+    /// - Parameters:
+    ///     - objectScope: All instances registered in given `ObjectsScope` will be discarded.
+    func resetObjectScope(_ objectScope: ObjectScope)
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - name:        A registration name, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    func register<Service>(_ serviceType: Service.Type, name: String?, factory: @escaping (Resolver) -> Service) -> ServiceEntry<Service>
+
+    /// This method is designed for the use to extend Swinject functionality.
+    /// Do NOT use this method unless you intend to write an extension or plugin to Swinject framework.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///   - name:        A registration name.
+    ///   - option:      A service key option for an extension/plugin.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    func _register<Service, Arguments>(_ serviceType: Service.Type, factory: @escaping (Arguments) -> Any, name: String?, option: ServiceKeyOption?) -> ServiceEntry<Service>
+
+    /// Returns a synchronized view of the container for thread safety.
+    /// The returned container is `Resolver` type. Call this method after you finish all service registrations
+    /// to the original container.
+    ///
+    /// - Returns: A synchronized container as `Resolver`.
+    func synchronize() -> Resolver
+
+    /// Adds behavior to the container. `Behavior.container(_:didRegisterService:withName:)` will be invoked for
+    /// each service registered to the `container` **after** the behavior has been added.
+    ///
+    /// - Parameters:
+    ///     - behavior: Behavior to be added to the container
+    func addBehavior(_ behavior: Behavior)
+}

--- a/Sources/ContainerProtocol.swift
+++ b/Sources/ContainerProtocol.swift
@@ -10,7 +10,6 @@ import Foundation
 
 public protocol ContainerProtocol {
     func removeAll()
-
     /// Discards instances for services registered in the given `ObjectsScopeProtocol`.
     ///
     /// **Example usage:**
@@ -19,7 +18,6 @@ public protocol ContainerProtocol {
     /// - Parameters:
     ///     - objectScope: All instances registered in given `ObjectsScopeProtocol` will be discarded.
     func resetObjectScope(_ objectScope: ObjectScopeProtocol)
-
     /// Discards instances for services registered in the given `ObjectsScope`. It performs the same operation
     /// as `resetObjectScope(_:ObjectScopeProtocol)`, but provides more convenient usage syntax.
     ///
@@ -29,7 +27,7 @@ public protocol ContainerProtocol {
     /// - Parameters:
     ///     - objectScope: All instances registered in given `ObjectsScope` will be discarded.
     func resetObjectScope(_ objectScope: ObjectScope)
-
+    
     /// Adds a registration for the specified service with the factory closure to specify how the service is
     /// resolved with dependencies.
     ///
@@ -43,7 +41,19 @@ public protocol ContainerProtocol {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
-    func register<Service>(_ serviceType: Service.Type, name: String?, factory: @escaping (Resolver) -> Service) -> ServiceEntry<Service>
+    @discardableResult
+    func register<Service>(
+        _ serviceType: Service.Type,
+        name: String?,
+        factory: @escaping (Resolver) -> Service
+    ) -> ServiceEntry<Service>
+    
+    /// Duplicate but without name because protocols do not allow default arguments
+    @discardableResult
+    func register<Service>(
+        _ serviceType: Service.Type,
+        factory: @escaping (Resolver) -> Service
+    ) -> ServiceEntry<Service>
 
     /// This method is designed for the use to extend Swinject functionality.
     /// Do NOT use this method unless you intend to write an extension or plugin to Swinject framework.
@@ -58,7 +68,12 @@ public protocol ContainerProtocol {
     ///   - option:      A service key option for an extension/plugin.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
-    func _register<Service, Arguments>(_ serviceType: Service.Type, factory: @escaping (Arguments) -> Any, name: String?, option: ServiceKeyOption?) -> ServiceEntry<Service>
+    func _register<Service, Arguments>(
+            _ serviceType: Service.Type,
+            factory: @escaping (Arguments) -> Any,
+            name: String?,
+            option: ServiceKeyOption?
+    ) -> ServiceEntry<Service>
 
     /// Returns a synchronized view of the container for thread safety.
     /// The returned container is `Resolver` type. Call this method after you finish all service registrations

--- a/Sources/FunctionType.swift
+++ b/Sources/FunctionType.swift
@@ -7,4 +7,4 @@
 //
 
 // Type alias to expect a closure.
-internal typealias FunctionType = Any
+public typealias FunctionType = Any

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // A generic-type-free protocol to be the type of values in a strongly-typed collection.
-internal protocol ServiceEntryProtocol: AnyObject {
+public protocol ServiceEntryProtocol: AnyObject {
     func describeWithKey(_ serviceKey: ServiceKey) -> String
     var objectScope: ObjectScopeProtocol { get }
     var storage: InstanceStorage { get }
@@ -22,18 +22,18 @@ internal protocol ServiceEntryProtocol: AnyObject {
 /// As a returned instance from a `register` method of a `Container`, some configurations can be added.
 public final class ServiceEntry<Service>: ServiceEntryProtocol {
     fileprivate var initCompletedActions: [(Resolver, Service) -> Void] = []
-    internal let serviceType: Any.Type
+    public let serviceType: Any.Type
     internal let argumentsType: Any.Type
 
-    internal let factory: FunctionType
+    public let factory: FunctionType
     internal weak var container: Container?
 
-    internal var objectScope: ObjectScopeProtocol = ObjectScope.graph
-    internal lazy var storage: InstanceStorage = { [unowned self] in
+    public var objectScope: ObjectScopeProtocol = ObjectScope.graph
+    public lazy var storage: InstanceStorage = { [unowned self] in
         self.objectScope.makeStorage()
     }()
 
-    internal var initCompleted: FunctionType? {
+    public var initCompleted: FunctionType? {
         guard !initCompletedActions.isEmpty else { return nil }
 
         return {[weak self] (resolver: Resolver, service: Any) -> Void in
@@ -94,7 +94,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
         return self
     }
 
-    internal func describeWithKey(_ serviceKey: ServiceKey) -> String {
+    public func describeWithKey(_ serviceKey: ServiceKey) -> String {
         return description(
             serviceType: serviceType,
             serviceKey: serviceKey,

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -42,7 +42,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
         }
     }
 
-    internal init(serviceType: Service.Type, argumentsType: Any.Type, factory: FunctionType) {
+    public init(serviceType: Service.Type, argumentsType: Any.Type, factory: FunctionType) {
         self.serviceType = serviceType
         self.argumentsType = argumentsType
         self.factory = factory

--- a/Sources/ServiceKey.swift
+++ b/Sources/ServiceKey.swift
@@ -15,13 +15,13 @@ public protocol ServiceKeyOption: CustomStringConvertible {
 }
 
 // MARK: - ServiceKey
-internal struct ServiceKey {
+public struct ServiceKey {
     internal let serviceType: Any.Type
     internal let argumentsType: Any.Type
     internal let name: String?
     internal let option: ServiceKeyOption? // Used for SwinjectStoryboard or other extensions.
 
-    internal init(
+    public init(
         serviceType: Any.Type,
         argumentsType: Any.Type,
         name: String? = nil,
@@ -36,7 +36,7 @@ internal struct ServiceKey {
 
 // MARK: Hashable
 extension ServiceKey: Hashable {
-    var hashValue: Int {
+    public var hashValue: Int {
         return ObjectIdentifier(serviceType).hashValue
             ^ ObjectIdentifier(argumentsType).hashValue
             ^ (name?.hashValue ?? 0)
@@ -45,7 +45,7 @@ extension ServiceKey: Hashable {
 }
 
 // MARK: Equatable
-func == (lhs: ServiceKey, rhs: ServiceKey) -> Bool {
+public func == (lhs: ServiceKey, rhs: ServiceKey) -> Bool {
     return lhs.serviceType == rhs.serviceType
         && lhs.argumentsType == rhs.argumentsType
         && lhs.name == rhs.name

--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -11,6 +11,9 @@ import Foundation
 public final class SpinLock {
     private let lock =  NSLock()
 
+    public init() {
+    }
+    
     func sync<T>(action: () -> T) -> T {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal final class SpinLock {
+public final class SpinLock {
     private let lock =  NSLock()
 
     func sync<T>(action: () -> T) -> T {

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -177,6 +177,10 @@
 		CDD44AD71DEEED1000916595 /* WeakStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD44AD61DEEED1000916595 /* WeakStorageSpec.swift */; };
 		CDD44AD81DEEED1000916595 /* WeakStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD44AD61DEEED1000916595 /* WeakStorageSpec.swift */; };
 		CDD44AD91DEEED1000916595 /* WeakStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD44AD61DEEED1000916595 /* WeakStorageSpec.swift */; };
+		FD3FBA8920AC0924000BBE85 /* ContainerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */; };
+		FD3FBA8A20AC0924000BBE85 /* ContainerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */; };
+		FD3FBA8B20AC0924000BBE85 /* ContainerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */; };
+		FD3FBA8C20AC0924000BBE85 /* ContainerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */; };
 		FF15F7831EDCE81B00F96686 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF15F77F1EDCE81600F96686 /* Nimble.framework */; };
 		FF15F7841EDCE81B00F96686 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF15F7801EDCE81600F96686 /* Quick.framework */; };
 		FF15F7871EDCE82600F96686 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF15F7851EDCE82600F96686 /* Nimble.framework */; };
@@ -341,6 +345,7 @@
 		CDC4FCF3205028B00021C60F /* InstanceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceWrapper.swift; sourceTree = "<group>"; };
 		CDC4FCF820502A9A0021C60F /* LazySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazySpec.swift; sourceTree = "<group>"; };
 		CDD44AD61DEEED1000916595 /* WeakStorageSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakStorageSpec.swift; sourceTree = "<group>"; };
+		FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerProtocol.swift; sourceTree = "<group>"; };
 		FF15F77F1EDCE81600F96686 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		FF15F7801EDCE81600F96686 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		FF15F7851EDCE82600F96686 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
@@ -460,6 +465,7 @@
 				90B029781C185B1600A6A521 /* Assembler.swift */,
 				90B029741C18599200A6A521 /* Assembly.swift */,
 				981899E31B5FFE5800C702D0 /* Container.swift */,
+				FD3FBA8820AC0924000BBE85 /* ContainerProtocol.swift */,
 				CDBD0E6B2035EEBB0030F566 /* Container.TypeForwarding.swift */,
 				98B012BA1B82D6A400053A32 /* Container.Arguments.erb */,
 				CD89E3482036F2A800A9ED33 /* ServiceEntry.TypeForwarding.erb */,
@@ -957,6 +963,7 @@
 				98B012C01B82F68E00053A32 /* Resolver.swift in Sources */,
 				CD3C2CE01D98E47000863421 /* DebugHelper.swift in Sources */,
 				90B0297A1C185B1600A6A521 /* Assembler.swift in Sources */,
+				FD3FBA8A20AC0924000BBE85 /* ContainerProtocol.swift in Sources */,
 				CDC4FCF5205028B00021C60F /* InstanceWrapper.swift in Sources */,
 				CD5E9A3720515898009090F9 /* GraphIdentifier.swift in Sources */,
 				90B029761C18599200A6A521 /* Assembly.swift in Sources */,
@@ -1024,6 +1031,7 @@
 				CD3B32921DD6121500B208A3 /* InstanceStorage.swift in Sources */,
 				981899E41B5FFE5800C702D0 /* Container.swift in Sources */,
 				98B012B81B82D67300053A32 /* Container.Arguments.swift in Sources */,
+				FD3FBA8920AC0924000BBE85 /* ContainerProtocol.swift in Sources */,
 				9884E2A71B60B77400120259 /* ServiceKey.swift in Sources */,
 				9819701F1B6145D600EEB942 /* ObjectScope.swift in Sources */,
 				984BE3131CDA3FCF00BCF2AC /* _Resolver.swift in Sources */,
@@ -1078,6 +1086,7 @@
 				985011251BBE7E8900A2CCFC /* Resolver.swift in Sources */,
 				9850111E1BBE7E8900A2CCFC /* Container.swift in Sources */,
 				CD3C2CE11D98E47000863421 /* DebugHelper.swift in Sources */,
+				FD3FBA8B20AC0924000BBE85 /* ContainerProtocol.swift in Sources */,
 				CDC4FCF6205028B00021C60F /* InstanceWrapper.swift in Sources */,
 				CD5E9A3820515898009090F9 /* GraphIdentifier.swift in Sources */,
 				9850111F1BBE7E8900A2CCFC /* ServiceKey.swift in Sources */,
@@ -1107,6 +1116,7 @@
 				98689C9D1BBFC7EB0005C6D3 /* ObjectScope.swift in Sources */,
 				984774F31C02F25D0092A757 /* SynchronizedResolver.swift in Sources */,
 				CD3C2CE21D98E47000863421 /* DebugHelper.swift in Sources */,
+				FD3FBA8C20AC0924000BBE85 /* ContainerProtocol.swift in Sources */,
 				CDC4FCF7205028B00021C60F /* InstanceWrapper.swift in Sources */,
 				CD5E9A3920515898009090F9 /* GraphIdentifier.swift in Sources */,
 				98689CA01BBFC7EB0005C6D3 /* Resolver.swift in Sources */,

--- a/Tests/SwinjectTests/AssemblerSpec.swift
+++ b/Tests/SwinjectTests/AssemblerSpec.swift
@@ -52,7 +52,7 @@ class AssemblerSpec: QuickSpec {
                 let assembler = Assembler([], parent: nil, defaultObjectScope: ObjectScope.container)
 
                 assembler.apply(assembly: ContainerSpyAssembly())
-                let container = assembler.resolver.resolve(Container.self)
+                let container = assembler.resolver.resolve(ContainerProtocol.self)
                 let serviceEntry = container?.register(Animal.self) { _ in Siamese(name: "Siam") }
 
                 expect(serviceEntry?.objectScope) === ObjectScope.container
@@ -62,7 +62,7 @@ class AssemblerSpec: QuickSpec {
                 let assembler = Assembler([], parent: nil)
 
                 assembler.apply(assembly: ContainerSpyAssembly())
-                let container = assembler.resolver.resolve(Container.self)
+                let container = assembler.resolver.resolve(ContainerProtocol.self)
                 let serviceEntry = container?.register(Animal.self) { _ in Siamese(name: "Siam") }
 
                 expect(serviceEntry?.objectScope) === ObjectScope.graph
@@ -298,7 +298,7 @@ class AssemblerSpec: QuickSpec {
                                                defaultObjectScope: ObjectScope.container)
 
                 childAssembler.apply(assembly: ContainerSpyAssembly())
-                let container = childAssembler.resolver.resolve(Container.self)
+                let container = childAssembler.resolver.resolve(ContainerProtocol.self)
                 let serviceEntry = container?.register(Animal.self) { _ in Siamese(name: "Siam") }
 
                 expect(serviceEntry?.objectScope) === ObjectScope.container
@@ -310,7 +310,7 @@ class AssemblerSpec: QuickSpec {
                 let childAssembler = Assembler(parentAssembler: parentAssembler)
 
                 childAssembler.apply(assembly: ContainerSpyAssembly())
-                let container = childAssembler.resolver.resolve(Container.self)
+                let container = childAssembler.resolver.resolve(ContainerProtocol.self)
                 let serviceEntry = container?.register(Animal.self) { _ in Siamese(name: "Siam") }
 
                 expect(serviceEntry?.objectScope) === ObjectScope.graph

--- a/Tests/SwinjectTests/BasicAssembly.swift
+++ b/Tests/SwinjectTests/BasicAssembly.swift
@@ -10,7 +10,7 @@ import Swinject
 
 class AnimalAssembly: Assembly {
 
-    func assemble(container: Container) {
+    func assemble(container: ContainerProtocol) {
         container.register(Animal.self) { _ in
             return Cat(name: "Whiskers")
         }
@@ -19,7 +19,7 @@ class AnimalAssembly: Assembly {
 
 class FoodAssembly: Assembly {
 
-    func assemble(container: Container) {
+    func assemble(container: ContainerProtocol) {
         container.register(Food.self) { _ in
             return Sushi()
         }
@@ -28,7 +28,7 @@ class FoodAssembly: Assembly {
 
 class PersonAssembly: Assembly {
 
-    func assemble(container: Container) {
+    func assemble(container: ContainerProtocol) {
         container.register(PetOwner.self) { r in
             let definition = PetOwner()
             definition.favoriteFood = r.resolve(Food.self)
@@ -39,8 +39,8 @@ class PersonAssembly: Assembly {
 }
 
 class ContainerSpyAssembly: Assembly {
-    func assemble(container: Container) {
-        container.register(Container.self) { _ in
+    func assemble(container: ContainerProtocol) {
+        container.register(ContainerProtocol.self) { _ in
             return container
         }
     }

--- a/Tests/SwinjectTests/EmploymentAssembly.swift
+++ b/Tests/SwinjectTests/EmploymentAssembly.swift
@@ -55,7 +55,7 @@ final class EmploymentAssembly: Assembly {
         self.scope = scope
     }
 
-    func assemble(container: Container) {
+    func assemble(container: ContainerProtocol) {
         container.register(Customer.self) { _ in Customer() }.inObjectScope(scope)
 
         container.register(Employee.self) {

--- a/Tests/SwinjectTests/LoadAwareAssembly.swift
+++ b/Tests/SwinjectTests/LoadAwareAssembly.swift
@@ -16,7 +16,7 @@ class LoadAwareAssembly: Assembly {
         self.onLoad = onLoad
     }
 
-    func assemble(container: Container) {
+    func assemble(container: ContainerProtocol) {
         container.register(Animal.self) { _ in
             return Cat(name: "Bojangles")
         }


### PR DESCRIPTION
Swift is a protocol based language. In one project I faced the problem that it was difficult to write tests with a real container. I wanted to mock it out but because it was not a protocol this was difficult. I had to make some functions and types public as a downside of this approach. What do you think?