### PR TITLE
Use NSRecursiveLock instead of NSLock

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal final class SpinLock {
-    private let lock =  NSLock()
+    private let lock =  NSRecursiveLock()
 
     func sync<T>(action: () -> T) -> T {
         lock.lock()

--- a/Swinject.podspec
+++ b/Swinject.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Swinject"
-  s.version          = "2.4.0"
+  s.version          = "2.4.1"
   s.summary          = "Dependency injection framework for Swift"
   s.description      = <<-DESC
                        Swinject is a dependency injection framework for Swift, to manage the dependencies of types in your system.

--- a/Tests/SwinjectTests/Info.plist
+++ b/Tests/SwinjectTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
If you have a re-entrant resolve (i.e. when resolving "A" using synchronized(), "A" tries to resolve "B") it will deadlock:

"You should not use this class to implement a recursive lock. Calling the lock method twice on the same thread will lock up your thread permanently. Use the NSRecursiveLock class to implement recursive locks instead."