### PR TITLE
Add tests for nested thread safe resolver

### DIFF
--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal final class SpinLock {
-    private let lock =  NSRecursiveLock()
+    private let lock = NSRecursiveLock()
 
     func sync<T>(action: () -> T) -> T {
         lock.lock()


### PR DESCRIPTION
Adds tests as addition to #350, retrived from #269.

Replaces #269.