### PR TITLE
Patch for Lazy wrappers and Xcode 10/Swift 4.2

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -297,14 +297,14 @@ extension Container: Resolver {
 
         guard let currentObjectGraph = currentObjectGraph else { fatalError() }
 
-        if let persistedInstance = entry.storage.instance(inGraph: currentObjectGraph) as? Service {
-            return persistedInstance
+        if let persistedInstance = entry.storage.instance(inGraph: currentObjectGraph), let persistedService = persistedInstance as? Service {
+            return persistedService
         }
 
         let resolvedInstance = invoker(entry.factory as! Factory)
-        if let persistedInstance = entry.storage.instance(inGraph: currentObjectGraph) as? Service {
+        if let persistedInstance = entry.storage.instance(inGraph: currentObjectGraph), let persistedService = persistedInstance as? Service {
             // An instance for the key might be added by the factory invocation.
-            return persistedInstance
+            return persistedService
         }
         entry.storage.setInstance(resolvedInstance as Any, inGraph: currentObjectGraph)
 


### PR DESCRIPTION
After updating to Xcode 10 and Swift 4.2, my app started crashing in `InstanceWrapper::40`, as the `instance` was `nil`. Spent a bunch of time trying to figure out what was going on, and below is the breakdown.

In `Container::300`, the if-check was passing and `nil` was being returned, which didn't seem right. I assume type checking was somehow changed in the latest version of the compiler, and `Service` is treated as an optional?

I split the check into two pieces, and everything seems to work as it should. I assume there must be an explanation as to why this is happening, and possibly a better way to patch this up, but I thought I'd post this in case someone else has the same issue.

Note that even the most basic sample from [Delayed Injection](https://github.com/Swinject/Swinject/blob/master/Documentation/DelayedInjection.md) fails, so it's definitely nothing specific to our app:

```
struct LazyCounter {
    let integer: Lazy<Int>

    func testPrint() {
        print("printing")
        print(integer.instance)
        print(integer.instance)
        print(integer.instance)
    }
}

let container = Container()

var value = 0;
container.register(Int.self) { _ in
    value += 1;
    print("creating Int")
    return value;
}

container.register(LazyCounter.self) { resolver in
    let lazyInt = resolver.resolve(Lazy<Int>.self)!
    return LazyCounter(integer: lazyInt)
}

let counter = container.resolve(LazyCounter.self)!
counter.testPrint()
```