### PR TITLE
[WIP] Update to Xcode 10.2 and Swift 5.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.1
-github "Quick/Nimble" ~> 7.0
+github "Quick/Quick" "HEAD"
+github "Quick/Nimble" "HEAD"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.3.0"
-github "Quick/Quick" "v1.3.1"
+github "Quick/Nimble" "9a281b1cfa1c53d1e8bd92e1798e4e473af8d263"
+github "Quick/Quick" "f2b5a06440ea87eba1a167cab37bf6496646c52e"

--- a/Sources/Container.Logging.swift
+++ b/Sources/Container.Logging.swift
@@ -11,7 +11,7 @@ public typealias LoggingFunctionType = (String) -> Void
 public extension Container {
     /// Function to be used for logging debugging data.
     /// Default implementation writes to standard output.
-    public static var loggingFunction: LoggingFunctionType? {
+    static var loggingFunction: LoggingFunctionType? {
         get { return _loggingFunction }
         set { _loggingFunction = newValue }
     }

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -802,11 +802,11 @@
 				TargetAttributes = {
 					981899BB1B5FE63F00C702D0 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 					};
 					981899C41B5FE63F00C702D0 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 					};
 					981ABE801B5FC9DF00294975 = {
 						CreatedOnToolsVersion = 7.0;
@@ -1176,6 +1176,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1187,6 +1188,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1201,6 +1203,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1215,6 +1218,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1274,6 +1278,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1289,6 +1294,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1303,6 +1309,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1317,6 +1324,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1328,6 +1336,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -1340,6 +1349,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;
@@ -1352,6 +1362,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -1364,6 +1375,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.Swinject";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -1379,6 +1391,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1393,6 +1406,7 @@
 				INFOPLIST_FILE = Tests/SwinjectTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Run migration assistant, tests green and no new warnings, using HEAD of Quick and Nimble and had to manually set Swift version to 5.0 in both, will wait until a Swift 5.0 compatible version is out.

Will wait until Travis CI add Xcode 10.2 support to update CI config.