### PR TITLE
Swift 5/Swift 4.2 Compatibility Fix

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.1
-github "Quick/Nimble" ~> 7.0
+github "Quick/Quick" ~> 2.0
+github "Quick/Nimble" ~> 8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.3.3"
-github "Quick/Quick" "v1.3.4"
+github "Quick/Nimble" "v8.0.0"
+github "Quick/Quick" "v2.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.3.0"
-github "Quick/Quick" "v1.3.1"
+github "Quick/Nimble" "v7.3.3"
+github "Quick/Quick" "v1.3.4"

--- a/Sources/Container.Logging.swift
+++ b/Sources/Container.Logging.swift
@@ -11,7 +11,7 @@ public typealias LoggingFunctionType = (String) -> Void
 public extension Container {
     /// Function to be used for logging debugging data.
     /// Default implementation writes to standard output.
-    public static var loggingFunction: LoggingFunctionType? {
+    static var loggingFunction: LoggingFunctionType? {
         get { return _loggingFunction }
         set { _loggingFunction = newValue }
     }

--- a/Sources/GraphIdentifier.swift
+++ b/Sources/GraphIdentifier.swift
@@ -13,7 +13,7 @@ extension GraphIdentifier: Equatable, Hashable {
     public static func == (lhs: GraphIdentifier, rhs: GraphIdentifier) -> Bool {
         return lhs === rhs
     }
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self).hashValue)
     }

--- a/Sources/GraphIdentifier.swift
+++ b/Sources/GraphIdentifier.swift
@@ -13,6 +13,8 @@ extension GraphIdentifier: Equatable, Hashable {
     public static func == (lhs: GraphIdentifier, rhs: GraphIdentifier) -> Bool {
         return lhs === rhs
     }
-
-    public var hashValue: Int { return ObjectIdentifier(self).hashValue }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self).hashValue)
+    }
 }

--- a/Sources/ServiceKey.swift
+++ b/Sources/ServiceKey.swift
@@ -35,12 +35,12 @@ internal struct ServiceKey {
 }
 
 // MARK: Hashable
-extension ServiceKey: Hashable {
-    var hashValue: Int {
-        return ObjectIdentifier(serviceType).hashValue
-            ^ ObjectIdentifier(argumentsType).hashValue
-            ^ (name?.hashValue ?? 0)
-            ^ (option?.hashValue ?? 0)
+extension ServiceKey: Hashable {    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(serviceType))
+        hasher.combine(ObjectIdentifier(argumentsType))
+        hasher.combine(name?.hashValue ?? 0)
+        hasher.combine(option?.hashValue ?? 0)
     }
 }
 

--- a/Sources/ServiceKey.swift
+++ b/Sources/ServiceKey.swift
@@ -35,7 +35,7 @@ internal struct ServiceKey {
 }
 
 // MARK: Hashable
-extension ServiceKey: Hashable {    
+extension ServiceKey: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(serviceType))
         hasher.combine(ObjectIdentifier(argumentsType))


### PR DESCRIPTION
Enables Swinject to be run successfully as a dependency in a Swift 5 (Xcode 10.2b2) project.

Changes made:
- Migrate hashing functions to use Swift 4.2s `hash(into:)`.
- Remove redundant access modifier to eliminate Swift 5 warnings
- Bump Quick/Nimble private deps to latest release versions

All tests run successfully under Xcode 10.1 with the release versions of Quick and Nimble.

However, tests will not run using Xcode 10.2b2 as the current release versions of Quick and Nimble do not support the Swift 5 compiler.

This problem won't be encountered by people using Swinject as a dependency because Quick/Nimble are located in the private Cartfile.

Nevertheless, a quick test via temporarily bumping Quick/Nimble to their master branches (which support Swift 5 compiler) shows all tests complete successfully on all testable targets.
