### PR TITLE
fix-swift-package-manager-integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,6 @@ let package = Package(
                 "Quick",
                 "Nimble",
                 "Swinject"
-            ]),
+            ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,23 +1,19 @@
 // swift-tools-version:5.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Swinject",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "Swinject",
-            targets: ["Swinject"]),
+            targets: ["Swinject"])
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
-        .package(url: "https://github.com/Quick/Nimble", from: "8.0.1"),
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.1")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Swinject",
             dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,33 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "Swinject"
+    name: "Swinject",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Swinject",
+            targets: ["Swinject"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.1"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Swinject",
+            dependencies: [],
+            path: "Sources"),
+        .testTarget(
+            name: "SwinjectTests",
+            dependencies: [
+                "Quick",
+                "Nimble",
+                "Swinject"
+            ]),
+    ]
 )


### PR DESCRIPTION
With Swift 5.0 it wasn't possible to define Swinject as a dependency. Fixed Package.swift