### PR TITLE
Update Assembler.md

### DIFF
--- a/Documentation/Assembler.md
+++ b/Documentation/Assembler.md
@@ -61,7 +61,9 @@ protocol LogHandler {
 
 class Logger {
 
-    class var sharedInstance: Logger!
+    static let sharedInstance = Logger()
+    
+    private init() {}
 
     var logHandlers = [LogHandler]()
 


### PR DESCRIPTION
Edits Logger sample class to be 'compilable' (Classes cannot have `class` stored properties). To be a singleton, as referred, I've made the initializer private.