### PR TITLE
Add dynamic option for the library to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
     products: [
         .library(name: "Swinject",
                  targets: ["Swinject"]),
+        .library(name: "Swinject-Dynamic",
+                 type: .dynamic,
+                 targets: ["Swinject"]),
     ],
     targets: [
         .target(name: "Swinject",

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,11 @@ import PackageDescription
 let package = Package(
     name: "Swinject",
     products: [
-        .library(name: "Swinject", targets: ["Swinject"]),
+        .library(name: "Swinject",
+                 targets: ["Swinject"]),
     ],
-    dependencies: [],
     targets: [
-        .target(name: "Swinject", dependencies: [], path: "Sources"),
+        .target(name: "Swinject",
+                path: "Sources"),
     ]
 )


### PR DESCRIPTION
This is a pattern I've seen in a few other libraries to get around Xcode's lack of support for choosing a dynamic library when linking to a project.