### PR TITLE
Add SynchronizedResolver property to Resolver protocol

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -261,6 +261,9 @@ extension Container: _Resolver {
 // MARK: - Resolver
 
 extension Container: Resolver {
+
+    public var synchronizedResolver: Resolver { synchronize() }
+
     /// Retrieves the instance with the specified service type.
     ///
     /// - Parameter serviceType: The service type to resolve.

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -278,4 +278,6 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
     ) -> Service?
+
+    var synchronizedResolver: Resolver { get }
 }

--- a/Sources/SynchronizedResolver.swift
+++ b/Sources/SynchronizedResolver.swift
@@ -24,6 +24,9 @@ extension SynchronizedResolver: _Resolver {
 }
 
 extension SynchronizedResolver: Resolver {
+    
+    var synchronizedResolver: Resolver { self }
+
     internal func resolve<Service>(_ serviceType: Service.Type) -> Service? {
         return container.lock.sync {
             self.container.resolve(serviceType)


### PR DESCRIPTION
- Alternate resolution to #221 / #445 
- Expose a _`SynchronizedResolver`_ property in the `Resolver` protocol.
- We use the Viper pattern, and have the architecture that a `Resolver` might be passed into some components (e.g. the Module), so that other components can be dynamically generated:

```
    public func assemble(container: Container) {
        container.register(FooModule.self) { resolver in
            FooModuleImplementation(resolver: resolver.synchronizedResolver)
        }
    }
```

- This causes thread-safety problems, however
- This PR is a _possible_ solution, although it is a little untidy:
  - Even better would be somehow adding configurability/refactoring, [so that the `SynchronizedResolver` also resolves dependencies using itself](https://github.com/Swinject/Swinject/blob/master/Sources/SynchronizedResolver.swift#L20-L36)
  - Currently a `SynchronizedResolver` only works for the initial `resolve(...)` call

Happy to discuss other options, but we will be using this as a fix for the time being