### PR TITLE
Feature/type safe naming

### DIFF
--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -1,9 +1,5 @@
 //
-//  Container.Arguments.swift
-//  Swinject
-//
-//  Created by Yoichi Tagaya on 8/18/15.
-//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -15,10 +11,10 @@
 //
 
 <% arg_count = 9 %>
-
 import Foundation
 
 // MARK: - Registeration with Arguments
+
 extension Container {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
@@ -39,8 +35,8 @@ extension Container {
     public func register<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, <%= arg_types %>) -> Service) -> ServiceEntry<Service>
-    {
+        factory: @escaping (Resolver, <%= arg_types %>) -> Service
+    ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
 
@@ -48,6 +44,7 @@ extension Container {
 }
 
 // MARK: - Resolver with Arguments
+
 extension Container {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
@@ -66,8 +63,9 @@ extension Container {
     ///            and <%= arg_param_description %> is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
-        <%= arg_param_def %>) -> Service?
-    {
+        <%= arg_param_def %>
+
+    ) -> Service? {
         return resolve(serviceType, name: nil, <%= arg_param_name %>: <%= arg_param_call %>)
     }
 
@@ -81,10 +79,11 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            <%= arg_param_description %> and name is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
-        _ serviceType: Service.Type,
+        _: Service.Type,
         name: String?,
-        <%= arg_param_def %>) -> Service?
-    {
+        <%= arg_param_def %>
+
+    ) -> Service? {
         typealias FactoryType = ((Resolver, <%= arg_types %>)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, <%= arg_param_call %>)) }
     }

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -203,6 +203,7 @@ extension Container {
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
+
 }
 
 // MARK: - Resolver with Arguments
@@ -504,4 +505,5 @@ extension Container {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
     }
+
 }

--- a/Sources/Container.DedicatedIdentifier.erb
+++ b/Sources/Container.DedicatedIdentifier.erb
@@ -1,0 +1,63 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_description = i == 1 ? "#{i} argument" : "#{i} arguments" %>
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, <%= arg_types %>>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, <%= arg_types %>) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+<% end %>
+}

--- a/Sources/Container.DedicatedIdentifier.swift
+++ b/Sources/Container.DedicatedIdentifier.swift
@@ -1,0 +1,226 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> ServiceIdentifier.IdentifiedType
+    ) -> ServiceEntry<ServiceIdentifier.IdentifiedType> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+}

--- a/Sources/Container.TypeIdentifier.erb
+++ b/Sources/Container.TypeIdentifier.erb
@@ -1,0 +1,63 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_description = i == 1 ? "#{i} argument" : "#{i} arguments" %>
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, <%= arg_types %>) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+<% end %>
+}

--- a/Sources/Container.TypeIdentifier.swift
+++ b/Sources/Container.TypeIdentifier.swift
@@ -1,0 +1,226 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to register.
+    ///   - identifier:  A registration identifier, which is used to differentiate from other registrations
+    ///                  that have the same service and factory types.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: identifier?.rawValue, factory: factory)
+    }
+
+}

--- a/Sources/DedicatedIdentifier.swift
+++ b/Sources/DedicatedIdentifier.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public protocol DedicatedIdentifier: TypeIdentifier {
+    associatedtype IdentifiedType
+}

--- a/Sources/DedicatedIdentifier.swift
+++ b/Sources/DedicatedIdentifier.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+/// Defines a TypeIdentifier for types which can not extend `Identifiable`, such as protocols, tuples or closures
 public protocol DedicatedIdentifier: TypeIdentifier {
+    /// The type for which the `DedicatedIdentifier` is dedicated
     associatedtype IdentifiedType
 }

--- a/Sources/Identifiable.swift
+++ b/Sources/Identifiable.swift
@@ -5,5 +5,6 @@
 import Foundation
 
 public protocol Identifiable {
+    /// The type of identifier used to bind type identification to string based name identification in a `Container`
     associatedtype Identifier: TypeIdentifier
 }

--- a/Sources/Identifiable.swift
+++ b/Sources/Identifiable.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public protocol Identifiable {
+    associatedtype Identifier: TypeIdentifier
+}

--- a/Sources/Resolver.DedicatedIdentifier.erb
+++ b/Sources/Resolver.DedicatedIdentifier.erb
@@ -1,0 +1,57 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+
+extension Resolver {
+
+    /// Retrieves the instance with the specified service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the identifier is found.
+    @discardableResult
+    public func resolve<ServiceIdentifier: DedicatedIdentifier>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue)
+    }
+
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_param = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
+<%   arg_param_call = i == 1 ? "argument" : (1..i).map{ |n| "arg#{n}" }.join(", ") %>
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "list of #{i} arguments" %>
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            <%= arg_param_description %> and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, <%= arg_types %>>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        <%= arg_param %>
+
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, <%= arg_param_name %>: <%= arg_param_call %>)
+    }
+
+<% end %>
+}

--- a/Sources/Resolver.DedicatedIdentifier.swift
+++ b/Sources/Resolver.DedicatedIdentifier.swift
@@ -1,0 +1,184 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+
+extension Resolver {
+
+    /// Retrieves the instance with the specified service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the identifier is found.
+    @discardableResult
+    public func resolve<ServiceIdentifier: DedicatedIdentifier>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue)
+    }
+
+    /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            1 argument and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        argument: Arg1
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, argument: argument)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 2 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 3 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 4 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 5 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 6 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 7 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 8 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 9 arguments and identifier is found.
+    public func resolve<ServiceIdentifier: DedicatedIdentifier, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: ServiceIdentifier.IdentifiedType.Type,
+        identifier: ServiceIdentifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
+    ) -> ServiceIdentifier.IdentifiedType? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
+}

--- a/Sources/Resolver.TypeIdentifier.erb
+++ b/Sources/Resolver.TypeIdentifier.erb
@@ -1,0 +1,60 @@
+//
+//  Resolver.TypeIdentifier.swift
+//  Swinject-iOS
+//
+//  Created by Benjamin Lavialle on 01/12/2020.
+//  Copyright © 2018 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+extension Resolver {
+
+    /// Retrieves the instance with the specified service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the identifier is found.
+    @discardableResult
+    public func resolve<Service: Identifiable>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue)
+    }
+
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_param = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
+<%   arg_param_call = i == 1 ? "argument" : (1..i).map{ |n| "arg#{n}" }.join(", ") %>
+<%   arg_param_name = i == 1 ? "argument" : "arguments" %>
+<%   arg_param_description = i == 1 ? "#{i} argument" : "list of #{i} arguments" %>
+    /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            <%= arg_param_description %> and identifier is found.
+    public func resolve<Service: Identifiable, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        <%= arg_param %>
+
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, <%= arg_param_name %>: <%= arg_param_call %>)
+    }
+
+<% end %>
+}

--- a/Sources/Resolver.TypeIdentifier.swift
+++ b/Sources/Resolver.TypeIdentifier.swift
@@ -1,0 +1,187 @@
+//
+//  Resolver.TypeIdentifier.swift
+//  Swinject-iOS
+//
+//  Created by Benjamin Lavialle on 01/12/2020.
+//  Copyright © 2018 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Resolver.TypeIdentifier.swift is generated from Resolver.TypeIdentifier.erb by ERB.
+// Do NOT modify Resolver.TypeIdentifier.swift directly.
+// Instead, modify Resolver.TypeIdentifier.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+extension Resolver {
+
+    /// Retrieves the instance with the specified service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the identifier is found.
+    @discardableResult
+    public func resolve<Service: Identifiable>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue)
+    }
+
+    /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            1 argument and identifier is found.
+    public func resolve<Service: Identifiable, Arg1>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        argument: Arg1
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, argument: argument)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 2 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 3 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 4 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 5 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 6 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 7 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 8 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service type to resolve.
+    ///   - identifier:  The registration identifier.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no registration for the service type,
+    ///            list of 9 arguments and identifier is found.
+    public func resolve<Service: Identifiable, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        identifier: Service.Identifier? = nil,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
+    ) -> Service? {
+        resolve(serviceType, name: identifier?.rawValue, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
+}

--- a/Sources/Resolver.erb
+++ b/Sources/Resolver.erb
@@ -1,21 +1,16 @@
 //
-//  Resolver.swift
-//  Swinject
-//
-//  Created by Yoichi Tagaya on 8/18/15.
-//  Copyright (c) 2015 Swinject Contributors. All rights reserved.
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
 //
 // NOTICE:
 //
 // Resolver.swift is generated from Resolver.erb by ERB.
-// Do NOT modify Container.Arguments.swift directly.
+// Do NOT modify Resolver.swift directly.
 // Instead, modify Resolver.erb and run `script/gencode` at the project root directory to generate the code.
 //
 
 <% arg_count = 9 %>
-
 public protocol Resolver {
     /// Retrieves the instance with the specified service type.
     ///
@@ -48,7 +43,9 @@ public protocol Resolver {
     ///            and <%= arg_param_description %> is found.
     func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
-        <%= arg_param %>) -> Service?
+        <%= arg_param %>
+
+    ) -> Service?
 
     /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
     ///
@@ -62,8 +59,9 @@ public protocol Resolver {
     func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String?,
-        <%= arg_param %>) -> Service?
+        <%= arg_param %>
+
+    ) -> Service?
 
 <% end %>
-
 }

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -278,4 +278,5 @@ public protocol Resolver {
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
     ) -> Service?
+
 }

--- a/Sources/ServiceEntry.TypeForwarding.erb
+++ b/Sources/ServiceEntry.TypeForwarding.erb
@@ -1,9 +1,5 @@
 //
-//  ServiceEntry.TypeForwarding.swift
-//  Swinject-iOS
-//
-//  Created by Jakub Vaňo on 16/02/2018.
-//  Copyright © 2018 Swinject Contributors. All rights reserved.
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -15,7 +11,6 @@
 //
 
 <% type_count = 9 %>
-
 extension ServiceEntry {
     /// Adds another type which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
@@ -39,9 +34,9 @@ extension ServiceEntry {
     ///     - types: List of <%= i %> types resolution of which should be forwarded
     @discardableResult
     public func implements<<%= types %>>(<%= params %>) -> ServiceEntry<Service> {
-        return self<% (1..i).each do |k| %>.implements(type<%= k %>)<% end %>
-        
+        return implements(type<%= 1 %>)<% (2..i).each do |k| %>.implements(type<%= k %>)<% end %>
+
     }
-    
+
 <% end %>
 }

--- a/Sources/ServiceEntry.TypeForwarding.swift
+++ b/Sources/ServiceEntry.TypeForwarding.swift
@@ -102,4 +102,5 @@ extension ServiceEntry {
     public func implements<T1, T2, T3, T4, T5, T6, T7, T8, T9>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type, _ type6: T6.Type, _ type7: T7.Type, _ type8: T8.Type, _ type9: T9.Type) -> ServiceEntry<Service> {
         return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7).implements(type8).implements(type9)
     }
+
 }

--- a/Sources/SynchronizedResolver.Arguments.erb
+++ b/Sources/SynchronizedResolver.Arguments.erb
@@ -1,9 +1,5 @@
 //
-//  SynchronizedResolver.Arguments.swift
-//  Swinject
-//
-//  Created by Yoichi Tagaya on 11/23/15.
-//  Copyright © 2015 Swinject Contributors. All rights reserved.
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -15,8 +11,8 @@
 //
 
 <% arg_count = 9 %>
-
 // MARK: - Resolver with Arguments
+
 extension SynchronizedResolver {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
@@ -25,20 +21,22 @@ extension SynchronizedResolver {
 <%   arg_param_call = i == 1 ? "argument" : (1..i).map{ |n| "arg#{n}" }.join(", ") %>
     internal func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
-        <%= arg_param_def %>) -> Service?
-    {
+        <%= arg_param_def %>
+
+    ) -> Service? {
         return container.lock.sync {
-            return self.container.resolve(serviceType, <%= arg_param_name %>: <%= arg_param_call %>)
+            self.container.resolve(serviceType, <%= arg_param_name %>: <%= arg_param_call %>)
         }
     }
 
     internal func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String?,
-        <%= arg_param_def %>) -> Service?
-    {
+        <%= arg_param_def %>
+
+    ) -> Service? {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, <%= arg_param_name %>: <%= arg_param_call %>)
+            self.container.resolve(serviceType, name: name, <%= arg_param_name %>: <%= arg_param_call %>)
         }
     }
 

--- a/Sources/SynchronizedResolver.Arguments.swift
+++ b/Sources/SynchronizedResolver.Arguments.swift
@@ -183,4 +183,5 @@ extension SynchronizedResolver {
             self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }
     }
+
 }

--- a/Sources/TypeIdentifier.swift
+++ b/Sources/TypeIdentifier.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+public protocol TypeIdentifier {
+    var rawValue: String { get }
+}

--- a/Sources/TypeIdentifier.swift
+++ b/Sources/TypeIdentifier.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+
+/// Identifier binding typed identification with string based name identification in a `Container`
 public protocol TypeIdentifier {
     var rawValue: String { get }
 }

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -136,6 +136,18 @@
 		8329CE24DE7D6FB1A6D88B17 /* DebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE752946EBDAC1CB5823A39E /* DebugHelper.swift */; };
 		84E22DD92E4F02B70F3A17C5 /* ContainerSpec.Circularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D425BCEDCFC8C7CAC6CF85D /* ContainerSpec.Circularity.swift */; };
 		8586EE67C32C467F3716DFFA /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F388AD8E55D8C6F1E31D0522 /* FunctionType.swift */; };
+		873160AE258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */; };
+		873160AF258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */; };
+		873160B0258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */; };
+		873160B1258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */; };
+		873160B2258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */; };
+		873160B3258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */; };
+		873160B4258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */; };
+		873160B5258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */; };
+		873160B6258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
+		873160B7258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
+		873160B8258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
+		873160B9258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
 		87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
@@ -148,6 +160,10 @@
 		87820F4D258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
 		87820F4E258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
 		87820F4F258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
+		87820F55258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */; };
+		87820F56258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */; };
+		87820F57258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */; };
+		87820F58258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */; };
 		87FB12D90646AFA5AC739B15 /* ContainerSpec.CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB483EF286681035F8A98F43 /* ContainerSpec.CustomStringConvertible.swift */; };
 		88D3BB9CECA9F373FF882AFB /* ContainerSpec.CustomScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE954435F1C361FB14C24B /* ContainerSpec.CustomScope.swift */; };
 		8AF61540088BF00CEF29247A /* ContainerSpec.Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C662DAE2FD2FCCA8585DB89 /* ContainerSpec.Arguments.swift */; };
@@ -368,9 +384,13 @@
 		7605BDEF71547D0B17D7195A /* Container.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.TypeForwarding.swift; sourceTree = "<group>"; };
 		76238B6105E2E443A94CE595 /* ServiceEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEntry.swift; sourceTree = "<group>"; };
 		823617F3B8A9192F56B13331 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
+		873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.DedicatedIdentifier.swift; sourceTree = "<group>"; };
+		873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.TypeIdentifier.swift; sourceTree = "<group>"; };
+		873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.DedicatedIdentifier.swift; sourceTree = "<group>"; };
 		87820F39258B97E000DC6D6F /* TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeIdentifier.swift; sourceTree = "<group>"; };
 		87820F42258B985500DC6D6F /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DedicatedIdentifier.swift; sourceTree = "<group>"; };
+		87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.TypeIdentifier.swift; sourceTree = "<group>"; };
 		8B9785AAE94A5447FA307242 /* Swinject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swinject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		944B981A9157833AC3397B4A /* Assembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assembler.swift; sourceTree = "<group>"; };
 		957AFDACC07687608E5E5F7E /* ObjectScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectScope.swift; sourceTree = "<group>"; };
@@ -570,7 +590,9 @@
 				5922B783F35F436C528594C1 /* Assembly.swift */,
 				C8D8BA4B04A5F517AF663DCE /* Behavior.swift */,
 				C38F57E5E5BE1DC65C3DDAF6 /* Container.Arguments.swift */,
+				873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */,
 				B0F839BCDE52371FE49454B9 /* Container.Logging.swift */,
+				873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */,
 				172E48E07BA72BCBFB305E93 /* Container.swift */,
 				7605BDEF71547D0B17D7195A /* Container.TypeForwarding.swift */,
 				DE752946EBDAC1CB5823A39E /* DebugHelper.swift */,
@@ -584,6 +606,8 @@
 				A79864FE285C06A91E006806 /* ObjectScope.Standard.swift */,
 				957AFDACC07687608E5E5F7E /* ObjectScope.swift */,
 				EC379E27E9804FC6C0BA0842 /* Resolver.swift */,
+				873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */,
+				87820F54258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift */,
 				76238B6105E2E443A94CE595 /* ServiceEntry.swift */,
 				54FFC812F14E9976208B644F /* ServiceEntry.TypeForwarding.swift */,
 				BD2ED5B0128132DCD709777F /* ServiceKey.swift */,
@@ -941,19 +965,23 @@
 				23A8D7543ED9973F04C5BC93 /* FunctionType.swift in Sources */,
 				706A459CAE24E0D5054CEC30 /* GraphIdentifier.swift in Sources */,
 				B55E915211F19C91C622E068 /* InstanceStorage.swift in Sources */,
+				873160B7258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */,
 				BB78B5DA95DCE3A942C18910 /* InstanceWrapper.swift in Sources */,
 				055969F9EA3C1AD43B11E006 /* ObjectScope.Standard.swift in Sources */,
+				873160B3258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */,
 				62A1539A3B07EE3E1B72CF95 /* ObjectScope.swift in Sources */,
 				5BB768EFEB4BA7D1D05B4DCC /* Resolver.swift in Sources */,
 				3D86E87634E427DCE7A8CF81 /* ServiceEntry.TypeForwarding.swift in Sources */,
 				513BDFB32DCE5B048672C33D /* ServiceEntry.swift in Sources */,
 				A39172D39FE39D24A12A7257 /* ServiceKey.swift in Sources */,
 				2E8EB4C1459E0B1047E08338 /* SpinLock.swift in Sources */,
+				873160AF258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */,
 				C9F920F9CEDCD69113D85834 /* SynchronizedResolver.Arguments.swift in Sources */,
 				87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				D0668C3AB5ED89951B60DA2E /* SynchronizedResolver.swift in Sources */,
 				68DA3B5FB308092FE9B5C733 /* UnavailableItems.swift in Sources */,
 				138D38987ED00235C384DD26 /* _Resolver.swift in Sources */,
+				87820F56258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1098,19 +1126,23 @@
 				C34362994B2581F04EB818A2 /* FunctionType.swift in Sources */,
 				59AB5E84FD9B11B7D1CA2401 /* GraphIdentifier.swift in Sources */,
 				FF222640214C9F4DA56130C4 /* InstanceStorage.swift in Sources */,
+				873160B8258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */,
 				7000D01DCB05BF57BC89BCF8 /* InstanceWrapper.swift in Sources */,
 				FEAF6DE7BBDD922B61E0ED20 /* ObjectScope.Standard.swift in Sources */,
+				873160B4258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */,
 				B9566410214991FBA727BB37 /* ObjectScope.swift in Sources */,
 				EE4786524E79B10DB36FDB11 /* Resolver.swift in Sources */,
 				54A3ED20B6A9506B9D514098 /* ServiceEntry.TypeForwarding.swift in Sources */,
 				1A2759577A52C96E28BB44F0 /* ServiceEntry.swift in Sources */,
 				AEE58DEFB1764391B49E4EA0 /* ServiceKey.swift in Sources */,
 				CC57D5BBD5945E37B704B7B4 /* SpinLock.swift in Sources */,
+				873160B0258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */,
 				3F48DF31B4FAB90048A44A04 /* SynchronizedResolver.Arguments.swift in Sources */,
 				87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				31FF42AD5DFDB5FD7FAB5530 /* SynchronizedResolver.swift in Sources */,
 				58654C80A0946909D44F6BAD /* UnavailableItems.swift in Sources */,
 				D4D93174FF22D805953A727A /* _Resolver.swift in Sources */,
+				87820F57258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1131,19 +1163,23 @@
 				F98A1B2A226EE26A13C67F34 /* FunctionType.swift in Sources */,
 				CC64B74A022612990F57D51D /* GraphIdentifier.swift in Sources */,
 				D6B0E0FA93AD8D47AA07AE03 /* InstanceStorage.swift in Sources */,
+				873160B9258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */,
 				6A352D6A2C12D7BDABC38645 /* InstanceWrapper.swift in Sources */,
 				BDCBFD62903A1C0F8B35797C /* ObjectScope.Standard.swift in Sources */,
+				873160B5258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */,
 				130DDD2347169F885F420989 /* ObjectScope.swift in Sources */,
 				9CD3F07823D2E64DD636E00A /* Resolver.swift in Sources */,
 				1845CF466289264A5BBC0CCE /* ServiceEntry.TypeForwarding.swift in Sources */,
 				35C9BCE88B6D6567760D7389 /* ServiceEntry.swift in Sources */,
 				3957BFF436703E5C0434D41E /* ServiceKey.swift in Sources */,
 				4C44517A43BAAFB8E4E99255 /* SpinLock.swift in Sources */,
+				873160B1258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */,
 				DC0704139B41CA402DF1922A /* SynchronizedResolver.Arguments.swift in Sources */,
 				87820F3D258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				9CEB151A9DB8675B5AB48432 /* SynchronizedResolver.swift in Sources */,
 				95070453A9934F08F9E02E6C /* UnavailableItems.swift in Sources */,
 				FA6DD52FA4D4BB157A43CBEE /* _Resolver.swift in Sources */,
+				87820F58258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1164,19 +1200,23 @@
 				8586EE67C32C467F3716DFFA /* FunctionType.swift in Sources */,
 				0C56E93B497BBA17B0E408F4 /* GraphIdentifier.swift in Sources */,
 				AB05847EAB8D85A8679B5EC5 /* InstanceStorage.swift in Sources */,
+				873160B6258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */,
 				61357D47A1C4870FAA34377C /* InstanceWrapper.swift in Sources */,
 				FA89EFC16AEAC2EC333CEA81 /* ObjectScope.Standard.swift in Sources */,
+				873160B2258BB5C200D9901C /* Container.TypeIdentifier.swift in Sources */,
 				40DCC9D2F3ABC2B36C9DC8AE /* ObjectScope.swift in Sources */,
 				96BA7CCC6AEC192CAD3054E1 /* Resolver.swift in Sources */,
 				1120EBEC146D1EDDCC29AB17 /* ServiceEntry.TypeForwarding.swift in Sources */,
 				808983B2AF095E481615029E /* ServiceEntry.swift in Sources */,
 				E28F56015BFBB47A791856D3 /* ServiceKey.swift in Sources */,
 				7C87F64B425D439EFB2B9A07 /* SpinLock.swift in Sources */,
+				873160AE258BB5C200D9901C /* Container.DedicatedIdentifier.swift in Sources */,
 				744024F52826E2B351B38D58 /* SynchronizedResolver.Arguments.swift in Sources */,
 				87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				FAEDCCC2810D4FD8A7A7AF8D /* SynchronizedResolver.swift in Sources */,
 				4D631FA98F95F809740D6585 /* UnavailableItems.swift in Sources */,
 				7E57CE64E1356423F0F89FD3 /* _Resolver.swift in Sources */,
+				87820F55258B9E0900DC6D6F /* Resolver.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -148,6 +148,18 @@
 		873160B7258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
 		873160B8258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
 		873160B9258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */; };
+		873160F9258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */; };
+		873160FA258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */; };
+		873160FB258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */; };
+		873160FC258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */; };
+		87316102258CA97700D9901C /* AnimalIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316101258CA97700D9901C /* AnimalIdentifier.swift */; };
+		87316103258CA97700D9901C /* AnimalIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316101258CA97700D9901C /* AnimalIdentifier.swift */; };
+		87316104258CA97700D9901C /* AnimalIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316101258CA97700D9901C /* AnimalIdentifier.swift */; };
+		87316105258CA97700D9901C /* AnimalIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316101258CA97700D9901C /* AnimalIdentifier.swift */; };
+		8731612C258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
+		8731612D258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
+		8731612E258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
+		8731612F258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
 		87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
@@ -387,6 +399,9 @@
 		873160AB258BB5C100D9901C /* Container.DedicatedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.DedicatedIdentifier.swift; sourceTree = "<group>"; };
 		873160AC258BB5C200D9901C /* Container.TypeIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.TypeIdentifier.swift; sourceTree = "<group>"; };
 		873160AD258BB5C200D9901C /* Resolver.DedicatedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.DedicatedIdentifier.swift; sourceTree = "<group>"; };
+		873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.TypeIdentifier.swift; sourceTree = "<group>"; };
+		87316101258CA97700D9901C /* AnimalIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalIdentifier.swift; sourceTree = "<group>"; };
+		8731612B258CAAA600D9901C /* Cat.Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cat.Identifier.swift; sourceTree = "<group>"; };
 		87820F39258B97E000DC6D6F /* TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeIdentifier.swift; sourceTree = "<group>"; };
 		87820F42258B985500DC6D6F /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DedicatedIdentifier.swift; sourceTree = "<group>"; };
@@ -469,9 +484,11 @@
 			children = (
 				A982F3108666D12EA0810D52 /* .swiftlint.yml */,
 				FFBC1F44A2B361CB169F7B66 /* Animal.swift */,
+				87316101258CA97700D9901C /* AnimalIdentifier.swift */,
 				1525F92CDAA706A848343E2B /* AssemblerSpec.swift */,
 				FCC59458E04C20587D870946 /* BasicAssembly.swift */,
 				BEF07245CC462D98868097A3 /* BehaviorFakes.swift */,
+				8731612B258CAAA600D9901C /* Cat.Identifier.swift */,
 				47328731EED63322AD76FB3A /* Circularity.swift */,
 				2C662DAE2FD2FCCA8585DB89 /* ContainerSpec.Arguments.swift */,
 				0A55238408D01CA3199A54A5 /* ContainerSpec.Behavior.swift */,
@@ -482,6 +499,7 @@
 				1524909CA7B5BFA7E2BEE347 /* ContainerSpec.GraphCaching.swift */,
 				7196841DBEB28245AF90D79E /* ContainerSpec.swift */,
 				A8817F361F89EB6F454B8F89 /* ContainerSpec.TypeForwarding.swift */,
+				873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */,
 				077047532310E42432E94D83 /* EmploymentAssembly.swift */,
 				1271722CF77709A1173E7863 /* Food.swift */,
 				AEAC51C6D09DEBE863D5A06E /* Info.plist */,
@@ -990,11 +1008,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				12BDC39E183E9F24A676930B /* Animal.swift in Sources */,
+				87316102258CA97700D9901C /* AnimalIdentifier.swift in Sources */,
 				8B77C609B760B0B1198D515D /* AssemblerSpec.swift in Sources */,
 				1C1C0CB3F19349057B4FBDE1 /* BasicAssembly.swift in Sources */,
 				235DD35BC7B8CE15BA46A677 /* BehaviorFakes.swift in Sources */,
 				F355D8940486AF9DE89DD22E /* Circularity.swift in Sources */,
 				A197085CE442365D732EE6FE /* ContainerSpec.Arguments.swift in Sources */,
+				8731612C258CAAA600D9901C /* Cat.Identifier.swift in Sources */,
 				DCF03B6DB8F99A474F2B575C /* ContainerSpec.Behavior.swift in Sources */,
 				030256DFF226FE93C75833F5 /* ContainerSpec.Circularity.swift in Sources */,
 				88D3BB9CECA9F373FF882AFB /* ContainerSpec.CustomScope.swift in Sources */,
@@ -1013,6 +1033,7 @@
 				24D51AE9E7475581C19E12AD /* ServiceKeySpec.swift in Sources */,
 				C814B6BC8221EF2C84E58B56 /* SynchronizedResolverSpec.swift in Sources */,
 				59D1C096E0FAB6094D6D2E68 /* WeakStorageSpec.swift in Sources */,
+				873160F9258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1021,11 +1042,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				B78D64DC2B0332D562F39A82 /* Animal.swift in Sources */,
+				87316103258CA97700D9901C /* AnimalIdentifier.swift in Sources */,
 				6942CC4FFCA9DFCEE448A9CB /* AssemblerSpec.swift in Sources */,
 				9ECC88CB09E13FD179A1ED8E /* BasicAssembly.swift in Sources */,
 				FF9DCB0AB20B0DBBE79451BB /* BehaviorFakes.swift in Sources */,
 				F82A2357F3C86D24E1E1D712 /* Circularity.swift in Sources */,
 				64410D34965C716D21782147 /* ContainerSpec.Arguments.swift in Sources */,
+				8731612D258CAAA600D9901C /* Cat.Identifier.swift in Sources */,
 				D20B08D89E67C0BA45302266 /* ContainerSpec.Behavior.swift in Sources */,
 				E63B478AC633428999D7E53E /* ContainerSpec.Circularity.swift in Sources */,
 				0A8E435254D99275EDED84AC /* ContainerSpec.CustomScope.swift in Sources */,
@@ -1044,6 +1067,7 @@
 				593926C57DA312B31AEBACB5 /* ServiceKeySpec.swift in Sources */,
 				3180DAAFE61B960BC08BAF29 /* SynchronizedResolverSpec.swift in Sources */,
 				06AC1B35227A2D5E8DC66531 /* WeakStorageSpec.swift in Sources */,
+				873160FA258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1052,11 +1076,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA4990BFDE1BA41947B9C140 /* Animal.swift in Sources */,
+				87316105258CA97700D9901C /* AnimalIdentifier.swift in Sources */,
 				D8A69AA5E6AB9E9287BCDA0B /* AssemblerSpec.swift in Sources */,
 				6443FB8C5B3DD95740287398 /* BasicAssembly.swift in Sources */,
 				0CAD0368F908D3D285C6A9A9 /* BehaviorFakes.swift in Sources */,
 				69A27AA36C90A4D4A5FDDEFC /* Circularity.swift in Sources */,
 				8AF61540088BF00CEF29247A /* ContainerSpec.Arguments.swift in Sources */,
+				8731612F258CAAA600D9901C /* Cat.Identifier.swift in Sources */,
 				E6CFED8809163B7DBA6A0262 /* ContainerSpec.Behavior.swift in Sources */,
 				84E22DD92E4F02B70F3A17C5 /* ContainerSpec.Circularity.swift in Sources */,
 				2B54062B225800A92EBDCDFB /* ContainerSpec.CustomScope.swift in Sources */,
@@ -1075,6 +1101,7 @@
 				0D3457202BD8D4737A415594 /* ServiceKeySpec.swift in Sources */,
 				10E24A29F44F24CDB18B4D94 /* SynchronizedResolverSpec.swift in Sources */,
 				16DB7B41DA383C7A52B8131F /* WeakStorageSpec.swift in Sources */,
+				873160FC258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1083,11 +1110,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				270E79D1962E06A934455167 /* Animal.swift in Sources */,
+				87316104258CA97700D9901C /* AnimalIdentifier.swift in Sources */,
 				F181F802205438BC3E09AD5D /* AssemblerSpec.swift in Sources */,
 				5D17DB72B4986D174D69135B /* BasicAssembly.swift in Sources */,
 				1BA2596EFB6E7BF4D46E3C9D /* BehaviorFakes.swift in Sources */,
 				0E5336910C7B0A00E588940E /* Circularity.swift in Sources */,
 				DD34A07C633466922592B6C3 /* ContainerSpec.Arguments.swift in Sources */,
+				8731612E258CAAA600D9901C /* Cat.Identifier.swift in Sources */,
 				681AEC6C1C827E74E7BC53CA /* ContainerSpec.Behavior.swift in Sources */,
 				634554033DFFE58AD4C85F08 /* ContainerSpec.Circularity.swift in Sources */,
 				DB3F4166348694D7D287D341 /* ContainerSpec.CustomScope.swift in Sources */,
@@ -1106,6 +1135,7 @@
 				935EB3978CD45BFA301F459B /* ServiceKeySpec.swift in Sources */,
 				ED832F8CF534CA8F91ADB594 /* SynchronizedResolverSpec.swift in Sources */,
 				48C79F21528614C83BE6A283 /* WeakStorageSpec.swift in Sources */,
+				873160FB258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -136,6 +136,18 @@
 		8329CE24DE7D6FB1A6D88B17 /* DebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE752946EBDAC1CB5823A39E /* DebugHelper.swift */; };
 		84E22DD92E4F02B70F3A17C5 /* ContainerSpec.Circularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D425BCEDCFC8C7CAC6CF85D /* ContainerSpec.Circularity.swift */; };
 		8586EE67C32C467F3716DFFA /* FunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F388AD8E55D8C6F1E31D0522 /* FunctionType.swift */; };
+		87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
+		87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
+		87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
+		87820F3D258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
+		87820F43258B985500DC6D6F /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F42258B985500DC6D6F /* Identifiable.swift */; };
+		87820F44258B985500DC6D6F /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F42258B985500DC6D6F /* Identifiable.swift */; };
+		87820F45258B985500DC6D6F /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F42258B985500DC6D6F /* Identifiable.swift */; };
+		87820F46258B985500DC6D6F /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F42258B985500DC6D6F /* Identifiable.swift */; };
+		87820F4C258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
+		87820F4D258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
+		87820F4E258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
+		87820F4F258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */; };
 		87FB12D90646AFA5AC739B15 /* ContainerSpec.CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB483EF286681035F8A98F43 /* ContainerSpec.CustomStringConvertible.swift */; };
 		88D3BB9CECA9F373FF882AFB /* ContainerSpec.CustomScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE954435F1C361FB14C24B /* ContainerSpec.CustomScope.swift */; };
 		8AF61540088BF00CEF29247A /* ContainerSpec.Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C662DAE2FD2FCCA8585DB89 /* ContainerSpec.Arguments.swift */; };
@@ -356,6 +368,9 @@
 		7605BDEF71547D0B17D7195A /* Container.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.TypeForwarding.swift; sourceTree = "<group>"; };
 		76238B6105E2E443A94CE595 /* ServiceEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEntry.swift; sourceTree = "<group>"; };
 		823617F3B8A9192F56B13331 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
+		87820F39258B97E000DC6D6F /* TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeIdentifier.swift; sourceTree = "<group>"; };
+		87820F42258B985500DC6D6F /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DedicatedIdentifier.swift; sourceTree = "<group>"; };
 		8B9785AAE94A5447FA307242 /* Swinject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swinject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		944B981A9157833AC3397B4A /* Assembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assembler.swift; sourceTree = "<group>"; };
 		957AFDACC07687608E5E5F7E /* ObjectScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectScope.swift; sourceTree = "<group>"; };
@@ -559,8 +574,10 @@
 				172E48E07BA72BCBFB305E93 /* Container.swift */,
 				7605BDEF71547D0B17D7195A /* Container.TypeForwarding.swift */,
 				DE752946EBDAC1CB5823A39E /* DebugHelper.swift */,
+				87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */,
 				F388AD8E55D8C6F1E31D0522 /* FunctionType.swift */,
 				9B058F48AF289C3AC307C2F7 /* GraphIdentifier.swift */,
+				87820F42258B985500DC6D6F /* Identifiable.swift */,
 				5F7BC1C4169BB4382C6D3E1F /* Info.plist */,
 				3B7688D6F1E3466891D0582E /* InstanceStorage.swift */,
 				7101AB0DE88A5340F7EAAC04 /* InstanceWrapper.swift */,
@@ -574,6 +591,7 @@
 				74DE57FB3E8228904E6FE0D7 /* Swinject.h */,
 				1979933FD5852C28F6D8784A /* SynchronizedResolver.Arguments.swift */,
 				710204D1A678B791BB0FC60E /* SynchronizedResolver.swift */,
+				87820F39258B97E000DC6D6F /* TypeIdentifier.swift */,
 				39924B830576F62A4B528A37 /* UnavailableItems.swift */,
 			);
 			path = Sources;
@@ -918,6 +936,8 @@
 				1B36EE582AD6251A33C956F2 /* Container.TypeForwarding.swift in Sources */,
 				4A1AEFDC62BC395924AB2355 /* Container.swift in Sources */,
 				BAB2886500919D428F97215A /* DebugHelper.swift in Sources */,
+				87820F4D258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */,
+				87820F44258B985500DC6D6F /* Identifiable.swift in Sources */,
 				23A8D7543ED9973F04C5BC93 /* FunctionType.swift in Sources */,
 				706A459CAE24E0D5054CEC30 /* GraphIdentifier.swift in Sources */,
 				B55E915211F19C91C622E068 /* InstanceStorage.swift in Sources */,
@@ -930,6 +950,7 @@
 				A39172D39FE39D24A12A7257 /* ServiceKey.swift in Sources */,
 				2E8EB4C1459E0B1047E08338 /* SpinLock.swift in Sources */,
 				C9F920F9CEDCD69113D85834 /* SynchronizedResolver.Arguments.swift in Sources */,
+				87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				D0668C3AB5ED89951B60DA2E /* SynchronizedResolver.swift in Sources */,
 				68DA3B5FB308092FE9B5C733 /* UnavailableItems.swift in Sources */,
 				138D38987ED00235C384DD26 /* _Resolver.swift in Sources */,
@@ -1072,6 +1093,8 @@
 				5488A7839EF00BAC43CE2CEE /* Container.TypeForwarding.swift in Sources */,
 				D56BD23EC91E28CE6C6D6E78 /* Container.swift in Sources */,
 				0126F47EDE97A611D184682F /* DebugHelper.swift in Sources */,
+				87820F4E258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */,
+				87820F45258B985500DC6D6F /* Identifiable.swift in Sources */,
 				C34362994B2581F04EB818A2 /* FunctionType.swift in Sources */,
 				59AB5E84FD9B11B7D1CA2401 /* GraphIdentifier.swift in Sources */,
 				FF222640214C9F4DA56130C4 /* InstanceStorage.swift in Sources */,
@@ -1084,6 +1107,7 @@
 				AEE58DEFB1764391B49E4EA0 /* ServiceKey.swift in Sources */,
 				CC57D5BBD5945E37B704B7B4 /* SpinLock.swift in Sources */,
 				3F48DF31B4FAB90048A44A04 /* SynchronizedResolver.Arguments.swift in Sources */,
+				87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				31FF42AD5DFDB5FD7FAB5530 /* SynchronizedResolver.swift in Sources */,
 				58654C80A0946909D44F6BAD /* UnavailableItems.swift in Sources */,
 				D4D93174FF22D805953A727A /* _Resolver.swift in Sources */,
@@ -1102,6 +1126,8 @@
 				1AF1BB032596F2ADF9021F90 /* Container.TypeForwarding.swift in Sources */,
 				52E4C2C279904E90D5F37204 /* Container.swift in Sources */,
 				CF05649033EABCF21B15C535 /* DebugHelper.swift in Sources */,
+				87820F4F258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */,
+				87820F46258B985500DC6D6F /* Identifiable.swift in Sources */,
 				F98A1B2A226EE26A13C67F34 /* FunctionType.swift in Sources */,
 				CC64B74A022612990F57D51D /* GraphIdentifier.swift in Sources */,
 				D6B0E0FA93AD8D47AA07AE03 /* InstanceStorage.swift in Sources */,
@@ -1114,6 +1140,7 @@
 				3957BFF436703E5C0434D41E /* ServiceKey.swift in Sources */,
 				4C44517A43BAAFB8E4E99255 /* SpinLock.swift in Sources */,
 				DC0704139B41CA402DF1922A /* SynchronizedResolver.Arguments.swift in Sources */,
+				87820F3D258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				9CEB151A9DB8675B5AB48432 /* SynchronizedResolver.swift in Sources */,
 				95070453A9934F08F9E02E6C /* UnavailableItems.swift in Sources */,
 				FA6DD52FA4D4BB157A43CBEE /* _Resolver.swift in Sources */,
@@ -1132,6 +1159,8 @@
 				0F6B596CC2F819EF9CF5FE75 /* Container.TypeForwarding.swift in Sources */,
 				BF6475BEA46F81B30A6FA19E /* Container.swift in Sources */,
 				8329CE24DE7D6FB1A6D88B17 /* DebugHelper.swift in Sources */,
+				87820F4C258B989A00DC6D6F /* DedicatedIdentifier.swift in Sources */,
+				87820F43258B985500DC6D6F /* Identifiable.swift in Sources */,
 				8586EE67C32C467F3716DFFA /* FunctionType.swift in Sources */,
 				0C56E93B497BBA17B0E408F4 /* GraphIdentifier.swift in Sources */,
 				AB05847EAB8D85A8679B5EC5 /* InstanceStorage.swift in Sources */,
@@ -1144,6 +1173,7 @@
 				E28F56015BFBB47A791856D3 /* ServiceKey.swift in Sources */,
 				7C87F64B425D439EFB2B9A07 /* SpinLock.swift in Sources */,
 				744024F52826E2B351B38D58 /* SynchronizedResolver.Arguments.swift in Sources */,
+				87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */,
 				FAEDCCC2810D4FD8A7A7AF8D /* SynchronizedResolver.swift in Sources */,
 				4D631FA98F95F809740D6585 /* UnavailableItems.swift in Sources */,
 				7E57CE64E1356423F0F89FD3 /* _Resolver.swift in Sources */,

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -160,6 +160,10 @@
 		8731612D258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
 		8731612E258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
 		8731612F258CAAA600D9901C /* Cat.Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8731612B258CAAA600D9901C /* Cat.Identifier.swift */; };
+		87316135258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */; };
+		87316136258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */; };
+		87316137258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */; };
+		87316138258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */; };
 		87820F3A258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3B258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
 		87820F3C258B97E000DC6D6F /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87820F39258B97E000DC6D6F /* TypeIdentifier.swift */; };
@@ -402,6 +406,7 @@
 		873160F8258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.TypeIdentifier.swift; sourceTree = "<group>"; };
 		87316101258CA97700D9901C /* AnimalIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalIdentifier.swift; sourceTree = "<group>"; };
 		8731612B258CAAA600D9901C /* Cat.Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cat.Identifier.swift; sourceTree = "<group>"; };
+		87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssemblerSpec.TypeIdentifier.swift; sourceTree = "<group>"; };
 		87820F39258B97E000DC6D6F /* TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeIdentifier.swift; sourceTree = "<group>"; };
 		87820F42258B985500DC6D6F /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		87820F4B258B989A00DC6D6F /* DedicatedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DedicatedIdentifier.swift; sourceTree = "<group>"; };
@@ -486,6 +491,7 @@
 				FFBC1F44A2B361CB169F7B66 /* Animal.swift */,
 				87316101258CA97700D9901C /* AnimalIdentifier.swift */,
 				1525F92CDAA706A848343E2B /* AssemblerSpec.swift */,
+				87316134258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift */,
 				FCC59458E04C20587D870946 /* BasicAssembly.swift */,
 				BEF07245CC462D98868097A3 /* BehaviorFakes.swift */,
 				8731612B258CAAA600D9901C /* Cat.Identifier.swift */,
@@ -1032,6 +1038,7 @@
 				F022381D6B69750931480F6D /* ServiceEntrySpec.swift in Sources */,
 				24D51AE9E7475581C19E12AD /* ServiceKeySpec.swift in Sources */,
 				C814B6BC8221EF2C84E58B56 /* SynchronizedResolverSpec.swift in Sources */,
+				87316135258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */,
 				59D1C096E0FAB6094D6D2E68 /* WeakStorageSpec.swift in Sources */,
 				873160F9258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
@@ -1066,6 +1073,7 @@
 				353E676B57D140FCF2B930AA /* ServiceEntrySpec.swift in Sources */,
 				593926C57DA312B31AEBACB5 /* ServiceKeySpec.swift in Sources */,
 				3180DAAFE61B960BC08BAF29 /* SynchronizedResolverSpec.swift in Sources */,
+				87316136258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */,
 				06AC1B35227A2D5E8DC66531 /* WeakStorageSpec.swift in Sources */,
 				873160FA258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
@@ -1100,6 +1108,7 @@
 				B776AE100F31CAAF5A0C9BF1 /* ServiceEntrySpec.swift in Sources */,
 				0D3457202BD8D4737A415594 /* ServiceKeySpec.swift in Sources */,
 				10E24A29F44F24CDB18B4D94 /* SynchronizedResolverSpec.swift in Sources */,
+				87316138258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */,
 				16DB7B41DA383C7A52B8131F /* WeakStorageSpec.swift in Sources */,
 				873160FC258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);
@@ -1134,6 +1143,7 @@
 				4652D9934D8361274EBF00D1 /* ServiceEntrySpec.swift in Sources */,
 				935EB3978CD45BFA301F459B /* ServiceKeySpec.swift in Sources */,
 				ED832F8CF534CA8F91ADB594 /* SynchronizedResolverSpec.swift in Sources */,
+				87316137258CAF7F00D9901C /* AssemblerSpec.TypeIdentifier.swift in Sources */,
 				48C79F21528614C83BE6A283 /* WeakStorageSpec.swift in Sources */,
 				873160FB258CA83900D9901C /* ContainerSpec.TypeIdentifier.swift in Sources */,
 			);

--- a/Tests/SwinjectTests/AnimalIdentifier.swift
+++ b/Tests/SwinjectTests/AnimalIdentifier.swift
@@ -1,0 +1,17 @@
+//
+//  Animal.TypeIdentifier.swift
+//  Swinject
+//
+//  Created by Benjamin Lavialle on 18/12/2020.
+//
+
+import Foundation
+import Swinject
+
+internal enum AnimalIdentifier: String, DedicatedIdentifier {
+
+    typealias IdentifiedType = Animal
+
+    case myCat = "My Cat"
+    case myOtherCat = "My Other Cat"
+}

--- a/Tests/SwinjectTests/AssemblerSpec.TypeIdentifier.swift
+++ b/Tests/SwinjectTests/AssemblerSpec.TypeIdentifier.swift
@@ -1,0 +1,43 @@
+//
+//  AssemblerSpec.TypeIdentifier.swift
+//  Swinject
+//
+//  Created by Benjamin Lavialle on 18/12/2020.
+//
+
+import Foundation
+import Nimble
+import Quick
+@testable import Swinject
+
+class AssemblerTypeIdentifierSpec: QuickSpec {
+    override func spec() {
+        describe("Assembler dedicated identifier init") {
+            it("can identify with dedicated identifier in a container") {
+                let assembler = Assembler([
+                    AnimalTypeIdentifiedAssembly(),
+                ])
+                let cat = assembler.resolver.resolve(Animal.self, identifier: AnimalIdentifier.myCat)
+                expect(cat).toNot(beNil())
+                expect(cat!.name) == "Whiskers"
+                let otherCat = assembler.resolver.resolve(Animal.self, identifier: AnimalIdentifier.myOtherCat)
+                expect(otherCat).toNot(beNil())
+                expect(otherCat!.name) == "Sylvester"
+            }
+        }
+
+        describe("Assembler type identifier init") {
+            it("can identify with type identifier in a container") {
+                let assembler = Assembler([
+                    CatTypeIdentifiedAssembly(),
+                ])
+                let cat = assembler.resolver.resolve(Cat.self, identifier: .firstCat)
+                expect(cat).toNot(beNil())
+                expect(cat!.name) == "Whiskers"
+                let otherCat = assembler.resolver.resolve(Cat.self, identifier: .secondCat)
+                expect(otherCat).toNot(beNil())
+                expect(otherCat!.name) == "Sylvester"
+            }
+        }
+    }
+}

--- a/Tests/SwinjectTests/BasicAssembly.swift
+++ b/Tests/SwinjectTests/BasicAssembly.swift
@@ -38,3 +38,25 @@ class ContainerSpyAssembly: Assembly {
         }
     }
 }
+
+
+class AnimalTypeIdentifiedAssembly: Assembly {
+    func assemble(container: Container) {
+        container.register(Animal.self, identifier: AnimalIdentifier.myCat) { _ in
+            Cat(name: "Whiskers")
+        }
+        container.register(Animal.self, identifier: AnimalIdentifier.myOtherCat) { _ in
+            Cat(name: "Sylvester")
+        }
+    }
+}
+class CatTypeIdentifiedAssembly: Assembly {
+    func assemble(container: Container) {
+        container.register(Cat.self, identifier: .firstCat) { _ in
+            Cat(name: "Whiskers")
+        }
+        container.register(Cat.self, identifier: .secondCat) { _ in
+            Cat(name: "Sylvester")
+        }
+    }
+}

--- a/Tests/SwinjectTests/Cat.Identifier.swift
+++ b/Tests/SwinjectTests/Cat.Identifier.swift
@@ -1,0 +1,20 @@
+//
+//  Cat.Identifier.swift
+//  Swinject
+//
+//  Created by Benjamin Lavialle on 18/12/2020.
+//
+
+import Foundation
+import Swinject
+
+extension Cat: Identifiable {
+
+    typealias Identifier = SwinjectName
+
+    enum SwinjectName: String, TypeIdentifier {
+        case firstCat = "My First Cat"
+        case secondCat = "My Second Cat"
+    }
+
+}

--- a/Tests/SwinjectTests/ContainerSpec.TypeIdentifier.swift
+++ b/Tests/SwinjectTests/ContainerSpec.TypeIdentifier.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//
+
+import Nimble
+import Quick
+@testable import Swinject
+
+class ContainerSpec_TypeIdentifier: QuickSpec {
+    override func spec() {
+        var container: Container!
+        beforeEach {
+            container = Container()
+        }
+
+        it("describes a registration with dedicated identifier.") {
+            container.register(Animal.self, identifier: AnimalIdentifier.myCat) { _ in Cat() }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Animal, Name: \"\(AnimalIdentifier.myCat.rawValue)\", Factory: Resolver -> Animal, ObjectScope: graph }\n"
+                + "]"
+        }
+        it("describes a registration with dedicated identifier and arguments.") {
+            container.register(Animal.self, identifier: AnimalIdentifier.myCat) { _, arg1, arg2 in Cat(name: arg1, sleeping: arg2) }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Animal, Name: \"\(AnimalIdentifier.myCat.rawValue)\", Factory: (Resolver, String, Bool) -> Animal, ObjectScope: graph }\n"
+                + "]"
+        }
+        it("describes multiple registrations with dedicated identifiers.") {
+            container.register(Animal.self, identifier: AnimalIdentifier.myCat) { _ in Cat() }
+            container.register(Animal.self, identifier: AnimalIdentifier.myOtherCat) { _ in Cat() }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Animal, Name: \"\(AnimalIdentifier.myCat.rawValue)\", Factory: Resolver -> Animal, ObjectScope: graph },\n"
+                + "    { Service: Animal, Name: \"\(AnimalIdentifier.myOtherCat.rawValue)\", Factory: Resolver -> Animal, ObjectScope: graph }\n"
+                + "]"
+        }
+
+        it("describes a registration with type identifier.") {
+            container.register(Cat.self, identifier: .firstCat) { _ in Cat() }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Cat, Name: \"\(Cat.SwinjectName.firstCat.rawValue)\", Factory: Resolver -> Cat, ObjectScope: graph }\n"
+                + "]"
+        }
+        it("describes a registration with type identifier and arguments.") {
+            container.register(Cat.self, identifier: .firstCat) { _, arg1, arg2 in Cat(name: arg1, sleeping: arg2) }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Cat, Name: \"\(Cat.SwinjectName.firstCat.rawValue)\", Factory: (Resolver, String, Bool) -> Cat, ObjectScope: graph }\n"
+                + "]"
+        }
+        it("describes multiple registrations with type identifiers.") {
+            container.register(Cat.self, identifier: .firstCat) { _ in Cat() }
+            container.register(Cat.self, identifier: .secondCat) { _ in Cat() }
+
+            expect(container.description) ==
+                "[\n"
+                + "    { Service: Cat, Name: \"\(Cat.SwinjectName.firstCat.rawValue)\", Factory: Resolver -> Cat, ObjectScope: graph },\n"
+                + "    { Service: Cat, Name: \"\(Cat.SwinjectName.secondCat.rawValue)\", Factory: Resolver -> Cat, ObjectScope: graph }\n"
+                + "]"
+        }
+    }
+}

--- a/script/gencode
+++ b/script/gencode
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files="Sources/Container.Arguments Sources/SynchronizedResolver.Arguments Sources/Resolver Sources/ServiceEntry.TypeForwarding"
+files="Sources/Container.Arguments Sources/SynchronizedResolver.Arguments Sources/Resolver Sources/ServiceEntry.TypeForwarding Sources/Resolver.TypeIdentifier Sources/Resolver.DedicatedIdentifier Sources/Container.TypeIdentifier Sources/Container.DedicatedIdentifier"
 
 for file in $files; do
   echo "Generating code to $file.swift"


### PR DESCRIPTION
Add type safety to registration/resolving. 
When registering elements identified by name, we might leave literal strings in the code and/or keep a list of string identifying registered element. But there is not safety in case of changing an element type at registration without updating resolving, or any other way of switching types/string.

This PR adds:
* `TypeIdentifier` protocol to associate a type to a string name
* `Identifiable` protocol to statically bind a registrable type to a`TypeIdentifier`
* `DedicatedIdentifier` to bind types which can not extend a protocol such as protocols
* entensions over `Container` and `Resolver` to use this type safe identification on top of literal string naming

