### PR TITLE
Add support for DocC

### DIFF
--- a/Sources/Assembler.swift
+++ b/Sources/Assembler.swift
@@ -2,17 +2,17 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-/// The `Assembler` provides a means to build a container via `Assembly` instances.
+/// The ``Assembler`` provides a means to build a container via ``Assembly`` instances.
 public final class Assembler {
-    /// the container that each assembly will build its `Service` definitions into
+    /// the container that each assembly will build its ``Service`` definitions into
     private let container: Container
 
-    /// expose the container as a resolver so `Service` registration only happens within an assembly
+    /// expose the container as a resolver so ``Service`` registration only happens within an assembly
     public var resolver: Resolver {
         return container
     }
 
-    /// Will create an empty `Assembler`
+    /// Will create an empty ``Assembler``
     ///
     /// - parameter container: the baseline container
     ///
@@ -20,7 +20,7 @@ public final class Assembler {
         self.container = container!
     }
 
-    /// Will create an empty `Assembler`
+    /// Will create an empty ``Assembler``
     ///
     /// - parameter parentAssembler: the baseline assembler
     /// - parameter defaultObjectScope: default object scope for container
@@ -33,7 +33,7 @@ public final class Assembler {
         )
     }
 
-    /// Will create a new `Assembler` with the given `Assembly` instances to build a `Container`
+    /// Will create a new ``Assembler`` with the given ``Assembly`` instances to build a ``Container``
     ///
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter container:          the baseline container
@@ -47,7 +47,7 @@ public final class Assembler {
         }
     }
 
-    /// Will create a new `Assembler` with the given `Assembly` instances to build a `Container`
+    /// Will create a new ``Assembler`` with the given ``Assembly`` instances to build a ``Container``
     ///
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter container:          the baseline container
@@ -57,7 +57,7 @@ public final class Assembler {
         run(assemblies: assemblies)
     }
 
-    /// Will create a new `Assembler` with the given `Assembly` instances to build a `Container`
+    /// Will create a new ``Assembler`` with the given ``Assembly`` instances to build a ``Container``
     ///
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter parentAssembler:    the baseline assembler
@@ -67,7 +67,7 @@ public final class Assembler {
         self.init(_: assemblies, parent: parentAssembler)
     }
 
-    /// Will create a new `Assembler` with the given `Assembly` instances to build a `Container`
+    /// Will create a new ``Assembler`` with the given ``Assembly`` instances to build a ``Container``
     ///
     /// - parameter assemblies:         the list of assemblies to build the container from
     /// - parameter parent:             the baseline assembler
@@ -87,8 +87,8 @@ public final class Assembler {
     /// assembler's container.
     ///
     /// If this assembly type is load aware, the loaded hook will be invoked right after the container has assembled
-    /// since after each call to `addAssembly` the container is fully loaded in its current state. If you wish to
-    /// lazy load several assemblies that have interdependencies between each other use `appyAssemblies`
+    /// since after each call to ``apply(assembly:)`` the container is fully loaded in its current state. If you wish to
+    /// lazy load several assemblies that have interdependencies between each other use ``apply(assemblies:)``.
     ///
     /// - parameter assembly: the assembly to apply to the container
     ///
@@ -100,7 +100,7 @@ public final class Assembler {
     /// assembler's container
     ///
     /// If this assembly type is load aware, the loaded hook will be invoked right after the container has assembled
-    /// since after each call to `addAssembly` the container is fully loaded in its current state.
+    /// since after each call to ``apply(assemblies:)`` the container is fully loaded in its current state.
     ///
     /// - parameter assemblies: the assemblies to apply to the container
     ///

--- a/Sources/Assembly.swift
+++ b/Sources/Assembly.swift
@@ -2,17 +2,17 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-/// The `Assembly` provides a means to organize your `Service` registration in logic groups which allows
-/// the user to swap out different implementations of `Services` by providing different `Assembly` instances
-/// to the `Assembler`
+/// The ``Assembly`` provides a means to organize your `Service` registration in logic groups which allows
+/// the user to swap out different implementations of `Services` by providing different ``Assembly`` instances
+/// to the ``Assembler``
 public protocol Assembly {
-    /// Provide hook for `Assembler` to load Services into the provided container
+    /// Provide hook for ``Assembler`` to load Services into the provided container
     ///
-    /// - parameter container: the container provided by the `Assembler`
+    /// - parameter container: the container provided by the ``Assembler``
     ///
     func assemble(container: Container)
 
-    /// Provides a hook to the `Assembly` that will be called once the `Assembler` has loaded all `Assembly`
+    /// Provides a hook to the ``Assembly`` that will be called once the ``Assembler`` has loaded all ``Assembly``
     /// instances into the container.
     ///
     /// - parameter resolver: the resolver that can resolve instances from the built container

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -22,11 +22,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 1 argument to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1>(
         _ serviceType: Service.Type,
@@ -43,11 +43,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 2 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
@@ -64,11 +64,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 3 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
@@ -85,11 +85,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 4 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
@@ -106,11 +106,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 5 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
@@ -127,11 +127,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 6 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
@@ -148,11 +148,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 7 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
@@ -169,11 +169,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 8 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
@@ -190,11 +190,11 @@ extension Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` instance and 9 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
@@ -215,7 +215,7 @@ extension Container {
     ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 1 argument is found in the `Container`.
+    ///            and 1 argument is found in the ``Container``.
     public func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
         argument: Arg1
@@ -231,7 +231,7 @@ extension Container {
     ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            1 argument and name is found in the `Container`.
+    ///            1 argument and name is found in the ``Container``.
     public func resolve<Service, Arg1>(
         _: Service.Type,
         name: String?,
@@ -248,7 +248,7 @@ extension Container {
     ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 2 arguments is found in the `Container`.
+    ///            and list of 2 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2
@@ -264,7 +264,7 @@ extension Container {
     ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 2 arguments and name is found in the `Container`.
+    ///            list of 2 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2>(
         _: Service.Type,
         name: String?,
@@ -281,7 +281,7 @@ extension Container {
     ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 3 arguments is found in the `Container`.
+    ///            and list of 3 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
@@ -297,7 +297,7 @@ extension Container {
     ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 3 arguments and name is found in the `Container`.
+    ///            list of 3 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _: Service.Type,
         name: String?,
@@ -314,7 +314,7 @@ extension Container {
     ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 4 arguments is found in the `Container`.
+    ///            and list of 4 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
@@ -330,7 +330,7 @@ extension Container {
     ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 4 arguments and name is found in the `Container`.
+    ///            list of 4 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _: Service.Type,
         name: String?,
@@ -347,7 +347,7 @@ extension Container {
     ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 5 arguments is found in the `Container`.
+    ///            and list of 5 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
@@ -363,7 +363,7 @@ extension Container {
     ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 5 arguments and name is found in the `Container`.
+    ///            list of 5 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _: Service.Type,
         name: String?,
@@ -380,7 +380,7 @@ extension Container {
     ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 6 arguments is found in the `Container`.
+    ///            and list of 6 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
@@ -396,7 +396,7 @@ extension Container {
     ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 6 arguments and name is found in the `Container`.
+    ///            list of 6 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _: Service.Type,
         name: String?,
@@ -413,7 +413,7 @@ extension Container {
     ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 7 arguments is found in the `Container`.
+    ///            and list of 7 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
@@ -429,7 +429,7 @@ extension Container {
     ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 7 arguments and name is found in the `Container`.
+    ///            list of 7 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _: Service.Type,
         name: String?,
@@ -446,7 +446,7 @@ extension Container {
     ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 8 arguments is found in the `Container`.
+    ///            and list of 8 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
@@ -462,7 +462,7 @@ extension Container {
     ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 8 arguments and name is found in the `Container`.
+    ///            list of 8 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _: Service.Type,
         name: String?,
@@ -479,7 +479,7 @@ extension Container {
     ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 9 arguments is found in the `Container`.
+    ///            and list of 9 arguments is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
@@ -495,7 +495,7 @@ extension Container {
     ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 9 arguments and name is found in the `Container`.
+    ///            list of 9 arguments and name is found in the ``Container``.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _: Service.Type,
         name: String?,

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// The `Container` class represents a dependency injection container, which stores registrations of services
+/// The ``Container`` class represents a dependency injection container, which stores registrations of services
 /// and retrieves registered services with dependencies injected.
 ///
 /// **Example to register:**
@@ -40,10 +40,10 @@ public final class Container {
         self.defaultObjectScope = defaultObjectScope
     }
 
-    /// Instantiates a `Container`
+    /// Instantiates a ``Container``
     ///
     /// - Parameters
-    ///     - parent: The optional parent `Container`.
+    ///     - parent: The optional parent ``Container``.
     ///     - defaultObjectScope: Default object scope (graph if no scope is injected)
     ///     - behaviors: List of behaviors to be added to the container
     ///     - registeringClosure: The closure registering services to the new container instance.
@@ -101,11 +101,11 @@ public final class Container {
     ///   - name:        A registration name, which is used to differentiate from other registrations
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service>(
         _ serviceType: Service.Type,
@@ -121,13 +121,13 @@ public final class Container {
     /// - Parameters:
     ///   - serviceType: The service type to register.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
-    ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                  It takes a ``Resolver`` to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///   - name:        A registration name.
     ///   - option:      A service key option for an extension/plugin.
     ///
-    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     // swiftlint:disable:next identifier_name
     public func _register<Service, Arguments>(
@@ -152,10 +152,10 @@ public final class Container {
     }
 
     /// Returns a synchronized view of the container for thread safety.
-    /// The returned container is `Resolver` type. Call this method after you finish all service registrations
+    /// The returned container is ``Resolver`` type. Call this method after you finish all service registrations
     /// to the original container.
     ///
-    /// - Returns: A synchronized container as `Resolver`.
+    /// - Returns: A synchronized container as ``Resolver``.
     public func synchronize() -> Resolver {
         return SynchronizedResolver(container: self)
     }
@@ -266,7 +266,7 @@ extension Container: Resolver {
     /// - Parameter serviceType: The service type to resolve.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            is found in the `Container`.
+    ///            is found in the ``Container``.
     public func resolve<Service>(_ serviceType: Service.Type) -> Service? {
         return resolve(serviceType, name: nil)
     }
@@ -278,7 +278,7 @@ extension Container: Resolver {
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type and name
-    ///            is found in the `Container`.
+    ///            is found in the ``Container``.
     public func resolve<Service>(_: Service.Type, name: String?) -> Service? {
         return _resolve(name: name) { (factory: (Resolver) -> Any) in factory(self) }
     }

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-/// Storage provided by `ObjectScope`. It is used by `Container` to persist resolved instances.
+/// Storage provided by ``ObjectScope``. It is used by ``Container`` to persist resolved instances.
 public protocol InstanceStorage: AnyObject {
     var instance: Any? { get set }
     func graphResolutionCompleted()

--- a/Sources/InstanceWrapper.swift
+++ b/Sources/InstanceWrapper.swift
@@ -8,7 +8,7 @@ protocol InstanceWrapper {
 }
 
 /// Wrapper to enable delayed dependency instantiation.
-/// `Lazy<Type>` does not need to be explicitly registered into the `Container` - resolution will work
+/// `Lazy<Type>` does not need to be explicitly registered into the ``Container`` - resolution will work
 /// as long as there is a registration for the `Type`.
 public final class Lazy<Service>: InstanceWrapper {
     static var wrappedType: Any.Type { return Service.self }
@@ -27,7 +27,7 @@ public final class Lazy<Service>: InstanceWrapper {
     private var _instance: Service?
 
     /// Getter for the wrapped object.
-    /// It will be resolved from the `Container` when first accessed, all other calls will return the same instance.
+    /// It will be resolved from the ``Container`` when first accessed, all other calls will return the same instance.
     public var instance: Service {
         if let instance = _instance {
             return instance
@@ -49,7 +49,7 @@ public final class Lazy<Service>: InstanceWrapper {
 }
 
 /// Wrapper to enable delayed dependency instantiation.
-/// `Provider<Type>` does not need to be explicitly registered into the `Container` - resolution will work
+/// `Provider<Type>` does not need to be explicitly registered into the ``Container`` - resolution will work
 /// as long as there is a registration for the `Type`.
 public final class Provider<Service>: InstanceWrapper {
     static var wrappedType: Any.Type { return Service.self }
@@ -62,7 +62,7 @@ public final class Provider<Service>: InstanceWrapper {
     }
 
     /// Getter for the wrapped object.
-    /// New instance will be resolved from the `Container` every time it is accessed.
+    /// New instance will be resolved from the ``Container`` every time it is accessed.
     public var instance: Service {
         return factory() as! Service
     }

--- a/Sources/ObjectScope.Standard.swift
+++ b/Sources/ObjectScope.Standard.swift
@@ -3,18 +3,18 @@
 //
 
 extension ObjectScope {
-    /// A new instance is always created by the `Container` when a type is resolved.
+    /// A new instance is always created by the ``Container`` when a type is resolved.
     /// The instance is not shared.
     public static let transient = ObjectScope(storageFactory: TransientStorage.init, description: "transient")
 
     /// Instances are shared only when an object graph is being created,
-    /// otherwise a new instance is created by the `Container`. This is the default scope.
+    /// otherwise a new instance is created by the ``Container``. This is the default scope.
     public static let graph = ObjectScope(storageFactory: GraphStorage.init, description: "graph")
 
-    /// An instance provided by the `Container` is shared within the `Container` and its child `Containers`.
+    /// An instance provided by the ``Container`` is shared within the ``Container`` and its child `Containers`.
     public static let container = ObjectScope(storageFactory: PermanentStorage.init, description: "container")
 
-    /// An instance provided by the `Container` is shared within the `Container` and its child `Container`s
+    /// An instance provided by the ``Container`` is shared within the ``Container`` and its child ``Container``s
     /// as long as there are strong references to given instance. Otherwise new instance is created
     /// when resolving the type.
     public static let weak = ObjectScope(storageFactory: WeakStorage.init, description: "weak",

--- a/Sources/ObjectScope.swift
+++ b/Sources/ObjectScope.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-/// A configuration how an instance provided by a `Container` is shared in the system.
+/// A configuration how an instance provided by a ``Container`` is shared in the system.
 /// The configuration is ignored if it is applied to a value type.
 public protocol ObjectScopeProtocol: AnyObject {
     /// Used to create `InstanceStorage` to persist an instance for single service.
@@ -10,13 +10,13 @@ public protocol ObjectScopeProtocol: AnyObject {
     func makeStorage() -> InstanceStorage
 }
 
-/// Basic implementation of `ObjectScopeProtocol`.
+/// Basic implementation of ``ObjectScopeProtocol``.
 public class ObjectScope: ObjectScopeProtocol, CustomStringConvertible {
     public private(set) var description: String
     private var storageFactory: () -> InstanceStorage
     private let parent: ObjectScopeProtocol?
 
-    /// Instantiates an `ObjectScope` with storage factory and description.
+    /// Instantiates an ``ObjectScope`` with storage factory and description.
     ///  - Parameters:
     ///     - storageFactory:   Closure for creating an `InstanceStorage`
     ///     - description:      Description of object scope for `CustomStringConvertible` implementation

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -14,8 +14,8 @@ internal protocol ServiceEntryProtocol: AnyObject {
     var serviceType: Any.Type { get }
 }
 
-/// The `ServiceEntry<Service>` class represents an entry of a registered service type.
-/// As a returned instance from a `register` method of a `Container`, some configurations can be added.
+/// Represents an entry of a registered service type.
+/// As a returned instance from ``Container/register(_:name:factory:)-8gy9r``, some configurations can be added.
 public final class ServiceEntry<Service>: ServiceEntryProtocol {
     fileprivate var initCompletedActions: [(Resolver, Service) -> Void] = []
     internal let serviceType: Any.Type
@@ -56,7 +56,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
 
     /// Specifies the object scope to resolve the service.
     ///
-    /// - Parameter scope: The `ObjectScopeProtocol` value.
+    /// - Parameter scope: The ``ObjectScopeProtocol`` value.
     ///
     /// - Returns: `self` to add another configuration fluently.
     @discardableResult
@@ -66,10 +66,10 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
     }
 
     /// Specifies the object scope to resolve the service.
-    /// Performs the same functionality as `inObjectScope(_: ObjectScopeProtocol) -> Self`,
+    /// Performs the same functionality as ``inObjectScope(_:)-2xeke``,
     /// but provides more convenient usage syntax.
     ///
-    /// - Parameter scope: The `ObjectScope` value.
+    /// - Parameter scope: The ``ObjectScope`` value.
     ///
     /// - Returns: `self` to add another configuration fluently.
     @discardableResult

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -768,8 +768,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 0102B3F56FB5455C665EC043 /* Build configuration list for PBXProject "Swinject" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1233,6 +1231,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_DOCUMENTATION_COMPILER = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1471,6 +1470,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_DOCUMENTATION_COMPILER = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
This is a draft with changes to better support Apple's new DocC format for documentation. More info [here](https://developer.apple.com/videos/play/wwdc2021/10166/?time=1050).

Might make sense to keep this branch out of master until Xcode 13 is closer to release.

- [x] Build DocC on every build of the framework
- [x] Update method doc formats to better take advantage of DocC