### PR TITLE
Update Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,6 @@ Pull requests are more appreciated to improve Swinject or to fix problems. Any k
 
 ### Getting Started
 
-Framework dependencies of Swinject are managed with [Carthage](https://github.com/Carthage/Carthage/releases). Make sure you have its latest version installed. The latest installer is available at [the Carthage release page](https://github.com/Carthage/Carthage/releases).
-
 To setup a Swinject repository in your local Mac, run `git clone` command in Terminal.
 
 `git clone --recursive git@github.com:Swinject/Swinject.git`
@@ -29,10 +27,6 @@ To setup a Swinject repository in your local Mac, run `git clone` command in Ter
 Move to the Swinject directory.
 
 `cd Swinject`
-
-Then run `carthage` command to build the frameworks that Swinject uses.
-
-`carthage bootstrap`
 
 Now it is ready to open `Swinject.xcodeproj`. Modify the code, run unit tests, and submit your pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Move to the Swinject directory.
 
 Now it is ready to open `Swinject.xcodeproj`. Modify the code, run unit tests, and submit your pull request.
 
+### Project Generation
+
+If you need to add / change any project settings or files inside the `Sources` folder, remember to also update the `project.yml`, which keeps our project generation in sync with the `Swinject.xcodeproj`. 
+
 ### Code Style
 
 Please have a look at [GitHub Swift Style Guide](https://github.com/github/swift-style-guide), which the existing Swinject code tries to follow. If you have a case that is out of scope of the style guide, please try to match the style of the surrounding code.


### PR DESCRIPTION
This PR updates the Contribution Guide since it is no longer required to have Quick/Nimble as a dependency during tests.

This PR also includes a mention on project generation and remembers contributors to keep the project.yml file updated.   