### PR TITLE
Generate the project before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,18 @@ matrix:
         - swift build
         - swift test
     - env: JOB="POD_LINT"
-      osx_image: xcode12
+      osx_image: xcode12.5
       before_install:
       script:
         - pod lib lint
     - env: JOB="XCODE" DEST="OS=14.0.1,name=iPhone 8" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test" PLATFORM="iOS"
       osx_image: xcode12.5
     - env: JOB="XCODE" DEST="arch=x86_64" SCHEME="Swinject-macOS" SDK="macosx" ACTION="test" PLATFORM="OSX"
-      osx_image: xcode12
+      osx_image: xcode12.5
     - env: JOB="XCODE" DEST="OS=14.0,name=Apple TV 4K" SCHEME="Swinject-tvOS" SDK="appletvsimulator" ACTION="test" PLATFORM="tvOS"
-      osx_image: xcode12
+      osx_image: xcode12.5
     - env: JOB="XCODE" DEST="OS=7.0,name=Apple Watch Series 6 - 44mm" SCHEME="Swinject-watchOS" SDK="watchsimulator" ACTION="build" PLATFORM="watchOS"
-      osx_image: xcode12
+      osx_image: xcode12.5
 
 before_install:
   - xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ env:
     - PROJECT=Swinject.xcodeproj
 git:
   submodules: false
+addons:
+  homebrew:
+    packages:
+    - xcodegen
 matrix:
   include:
     - env: JOB="LINUX_SPM" SWIFT_VERSION="5.2.2"
@@ -38,6 +42,8 @@ before_install:
   - echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
   - echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
   - export XCODE_XCCONFIG_FILE="$xcconfig"
+before_script:
+  - xcodegen generate
 script:
   - set -o pipefail
   - xcodebuild "$ACTION" -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DEST" -configuration Release ENABLE_TESTABILITY=YES | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       script:
         - pod lib lint
     - env: JOB="XCODE" DEST="OS=14.0,name=iPhone 8" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test" PLATFORM="iOS"
-      osx_image: xcode12
+      osx_image: xcode12.5
     - env: JOB="XCODE" DEST="arch=x86_64" SCHEME="Swinject-macOS" SDK="macosx" ACTION="test" PLATFORM="OSX"
       osx_image: xcode12
     - env: JOB="XCODE" DEST="OS=14.0,name=Apple TV 4K" SCHEME="Swinject-tvOS" SDK="appletvsimulator" ACTION="test" PLATFORM="tvOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       dist: bionic
       before_install:
         - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+      before_script:
       script:
         - mv .Package.Test.swift Package.swift
         - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_install:
   - echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
   - export XCODE_XCCONFIG_FILE="$xcconfig"
 before_script:
+  - rm -r Swinject.xcodeproj
   - xcodegen generate
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       before_install:
       script:
         - pod lib lint
-    - env: JOB="XCODE" DEST="OS=14.0,name=iPhone 8" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test" PLATFORM="iOS"
+    - env: JOB="XCODE" DEST="OS=14.0.1,name=iPhone 8" SCHEME="Swinject-iOS" SDK="iphonesimulator" ACTION="test" PLATFORM="iOS"
       osx_image: xcode12.5
     - env: JOB="XCODE" DEST="arch=x86_64" SCHEME="Swinject-macOS" SDK="macosx" ACTION="test" PLATFORM="OSX"
       osx_image: xcode12


### PR DESCRIPTION
This pull request partially closes #474 

It ensures that the project being built is always updated with xcodegen. 
But it doesn't update the project committed to the repository.

To completely close this issue. We should:
- Stop versioning the project (I don't know which side effects may occur) 
- Guarantee the project is being generated at the time of the CD pipeline / makefile run.