### PR TITLE
Release v2.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ push-to-upstream:
 #
 # Make a release for Carthage.
 #
-VERSION_TAG=$(shell git describe --abbrev=0)
+VERSION_TAG=$(shell git describe --tags --abbrev=0)
 .PHONY: carthage-release
 carthage-release:
 ifeq ($(shell which gh),)

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 ifneq ($(VERSION_TAG),$(shell agvtool what-marketing-version -terse1))
 	$(error The version tag $(VERSION_TAG) does not match the version in Info.plist)
 endif
-	gh release create v$(VERSION_TAG) --draft
+	gh release create $(VERSION_TAG) --draft --title v$(VERSION_TAG) --notes ""
 	@echo Open https://github.com/Swinject/Swinject/releases/edit/$(VERSION_TAG) to describe the release and publish it.
 
 #

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ A guide to [submit issues](https://github.com/Swinject/Swinject/issues), to ask 
 
 ## Question?
 
-- [Slack](https://join.slack.com/t/swinject/shared_invite/enQtNjk0NjE0NjMzOTIyLTI5NWJiNDU5NGI1MTUwZDI3MDU2ZTM2YTMwMWRhMjI0ZmFlODk4MDI5OWUwNzY1YjlhOTRjYWM2NjZmOTVhNTU) feel free to discuss anything Swinject related.
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/swinject) we are trying to monitor questions tagged `swinject`
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Swinject
 [![CocoaPods Version](https://img.shields.io/cocoapods/v/Swinject.svg?style=flat)](http://cocoapods.org/pods/Swinject)
 [![License](https://img.shields.io/cocoapods/l/Swinject.svg?style=flat)](http://cocoapods.org/pods/Swinject)
 [![Platforms](https://img.shields.io/badge/platform-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Linux-lightgrey.svg)](http://cocoapods.org/pods/Swinject)
-[![Swift Version](https://img.shields.io/badge/Swift-2.2--3.1.x-F16D39.svg?style=flat)](https://developer.apple.com/swift)
+[![Swift Version](https://img.shields.io/badge/Swift-4.2--5.4-F16D39.svg?style=flat)](https://developer.apple.com/swift)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 Swinject is a lightweight [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) framework for Swift.
@@ -41,13 +41,9 @@ Dependency injection (DI) is a software design pattern that implements Inversion
 
 ## Requirements
 
-- iOS 8.0+ / Mac OS X 10.10+ / watchOS 2.0+ / tvOS 9.0+
-- Swift 2.2 or 2.3
-  - Xcode 7.0+
-- Swift 3
-  - Xcode 8.0+
-- Swift 3.2, 4.x
-  - Xcode 9.0+
+- iOS 9.0+ / Mac OS X 10.10+ / watchOS 2.0+ / tvOS 9.0+
+- Xcode 10.2+
+- Swift 4.2+
 - Carthage 0.18+ (if you use)
 - CocoaPods 1.1.1+ (if you use)
 
@@ -58,14 +54,6 @@ Swinject is available through [Carthage](https://github.com/Carthage/Carthage), 
 ### Carthage
 
 To install Swinject with Carthage, add the following line to your `Cartfile`.
-
-#### Swift 2.2 or 2.3
-
-```
-github "Swinject/Swinject" ~> 1.1.4
-```
-
-#### Swift 3.x or 4.x
 
 ```
 github "Swinject/Swinject"
@@ -81,21 +69,9 @@ Then run `carthage update --no-use-binaries` command or just `carthage update`. 
 
 To install Swinject with CocoaPods, add the following lines to your `Podfile`.
 
-#### Swift 2.2 or 2.3
-
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0' # or platform :osx, '10.10' if your target is OS X.
-use_frameworks!
-
-pod 'Swinject', '~> 1.1.4'
-```
-
-#### Swift 3.x
-
-```ruby
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0' # or platform :osx, '10.10' if your target is OS X.
+platform :ios, '9.0' # or platform :osx, '10.10' if your target is OS X.
 use_frameworks!
 
 pod 'Swinject'
@@ -114,7 +90,7 @@ in `Package.swift` add the following:
 dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/Swinject/Swinject.git", from: "2.7.1")
+    .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.0")
 ],
 targets: [
     .target(
@@ -202,10 +178,9 @@ class PersonViewController: UIViewController {
 
 ### With SwinjectStoryboard
 
-Import SwinjectStoryboard at the top of your swift source file if you use Swinject v2 in Swift 3.
+Import SwinjectStoryboard at the top of your swift source file.
 
 ```swift
-// Only Swinject v2 in Swift 3.
 import SwinjectStoryboard
 ```
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.1</string>
+	<string>2.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Swinject.podspec
+++ b/Swinject.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Swinject"
-  s.version          = "2.7.1"
+  s.version          = "2.8.0"
   s.summary          = "Dependency injection framework for Swift"
   s.description      = "Swinject is a dependency injection framework for Swift, to manage the dependencies of types in your system."
 

--- a/Tests/SwinjectTests/Info.plist
+++ b/Tests/SwinjectTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.1</string>
+	<string>2.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Made the new release, v2.8.0!
- Updated README.md to mention the supported Swift and Xcode versions.
- Removed the link to maintainers' Slack workspace (#438).
- Fixed bugs in Makefile to make a new release.