### PR TITLE
Add `--tags` option to one more `git describe` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 #
 # Push the commit and tag for the new version to upstream.
 #
-VERSION_TAG=$(shell git describe --abbrev=0)
+VERSION_TAG=$(shell git describe --tags --abbrev=0)
 ifndef UPSTREAM
 UPSTREAM=upstream
 endif


### PR DESCRIPTION
The following changes were insufficient to fix our Makefile.

- deaa002896efe565a2a7519fc9684297a4a43318
- 3ab73c441249aa4840feb0f41b10be02ce80d78f

In this PR, I added `--tags` option to one more `git describe` command.