### PR TITLE
Update Container to inherit NSObject

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -19,7 +19,7 @@ import Foundation
 ///
 /// where `A` and `X` are protocols, `B` is a type conforming `A`, and `Y` is a type conforming `X`
 /// and depending on `A`.
-public final class Container {
+public final class Container: NSObject {
     internal var services = [ServiceKey: ServiceEntryProtocol]()
     private let parent: Container? // Used by HierarchyObjectScope
     private var resolutionDepth = 0
@@ -334,8 +334,8 @@ extension Container: Resolver {
 
 // MARK: CustomStringConvertible
 
-extension Container: CustomStringConvertible {
-    public var description: String {
+extension Container {
+    public override var description: String {
         return "["
             + services.map { "\n    { \($1.describeWithKey($0)) }" }.sorted().joined(separator: ",")
             + "\n]"


### PR DESCRIPTION
For versatility, I updated `Container` to inherit from `NSObject`.

Actually, I want use [Then](https://github.com/devxoul/Then). (very awesome sugar)
Like this.
```swift
let container = Container().then {
   $0.register(Animal.self) { _ in Cat(name: "Mimi") }
}
```
Isn't it really that simple?

If we inherit from NSObject, we can do cool things like this.
Thanks.