### PR TITLE
Internalize `Container` synchronization

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -25,6 +25,7 @@ public final class Container {
     private var resolutionDepth = 0
     private let debugHelper: DebugHelper
     private let defaultObjectScope: ObjectScope
+    private let synchronized: Bool
     internal var currentObjectGraph: GraphIdentifier?
     internal let lock: RecursiveLock // Used by SynchronizedResolver.
     internal var behaviors = [Behavior]()
@@ -32,12 +33,14 @@ public final class Container {
     internal init(
         parent: Container? = nil,
         debugHelper: DebugHelper,
-        defaultObjectScope: ObjectScope = .graph
+        defaultObjectScope: ObjectScope = .graph,
+        synchronized: Bool = false
     ) {
         self.parent = parent
         self.debugHelper = debugHelper
         lock = parent.map { $0.lock } ?? RecursiveLock()
         self.defaultObjectScope = defaultObjectScope
+        self.synchronized = synchronized
     }
 
     /// Instantiates a ``Container``
@@ -157,7 +160,10 @@ public final class Container {
     ///
     /// - Returns: A synchronized container as ``Resolver``.
     public func synchronize() -> Resolver {
-        return SynchronizedResolver(container: self)
+        return Container(parent: self,
+                         debugHelper: debugHelper,
+                         defaultObjectScope: defaultObjectScope,
+                         synchronized: true)
     }
 
     /// Adds behavior to the container. `Behavior.container(_:didRegisterService:withName:)` will be invoked for
@@ -170,7 +176,16 @@ public final class Container {
     }
 
     internal func restoreObjectGraph(_ identifier: GraphIdentifier) {
-        currentObjectGraph = identifier
+        let action = { [weak self] in
+            self?.currentObjectGraph = identifier
+        }
+        if synchronized {
+            lock.sync {
+                action()
+            }
+        } else {
+            action()
+        }
     }
 }
 
@@ -293,32 +308,42 @@ extension Container: Resolver {
 
     fileprivate func resolve<Service, Factory>(
         entry: ServiceEntryProtocol,
-        invoker: (Factory) -> Any
+        invoker: @escaping (Factory) -> Any
     ) -> Service? {
-        incrementResolutionDepth()
-        defer { decrementResolutionDepth() }
+        let resolution: () -> Service? = { [weak self] in
+            guard let self = self else { return nil }
+            self.incrementResolutionDepth()
+            defer { self.decrementResolutionDepth() }
 
-        guard let currentObjectGraph = currentObjectGraph else {
-            fatalError("If accessing container from multiple threads, make sure to use a synchronized resolver.")
+            guard let currentObjectGraph = self.currentObjectGraph else {
+                fatalError("If accessing container from multiple threads, make sure to use a synchronized resolver.")
+            }
+
+            if let persistedInstance = self.persistedInstance(Service.self, from: entry, in: currentObjectGraph) {
+                return persistedInstance
+            }
+
+            let resolvedInstance = invoker(entry.factory as! Factory)
+            if let persistedInstance = self.persistedInstance(Service.self, from: entry, in: currentObjectGraph) {
+                // An instance for the key might be added by the factory invocation.
+                return persistedInstance
+            }
+            entry.storage.setInstance(resolvedInstance as Any, inGraph: currentObjectGraph)
+
+            if let completed = entry.initCompleted as? (Resolver, Any) -> Void,
+                let resolvedInstance = resolvedInstance as? Service {
+                completed(self, resolvedInstance)
+            }
+
+            return resolvedInstance as? Service
         }
-
-        if let persistedInstance = persistedInstance(Service.self, from: entry, in: currentObjectGraph) {
-            return persistedInstance
+        if synchronized {
+            return lock.sync {
+                return resolution()
+            }
+        } else {
+            return resolution()
         }
-
-        let resolvedInstance = invoker(entry.factory as! Factory)
-        if let persistedInstance = persistedInstance(Service.self, from: entry, in: currentObjectGraph) {
-            // An instance for the key might be added by the factory invocation.
-            return persistedInstance
-        }
-        entry.storage.setInstance(resolvedInstance as Any, inGraph: currentObjectGraph)
-
-        if let completed = entry.initCompleted as? (Resolver, Any) -> Void,
-            let resolvedInstance = resolvedInstance as? Service {
-            completed(self, resolvedInstance)
-        }
-
-        return resolvedInstance as? Service
     }
 
     private func persistedInstance<Service>(

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -310,8 +310,9 @@ extension Container: Resolver {
         entry: ServiceEntryProtocol,
         invoker: @escaping (Factory) -> Any
     ) -> Service? {
-        let resolution: () -> Service? = { [weak self] in
-            guard let self = self else { return nil }
+        // No need to use weak self since the resolution will be executed before
+        // this function exits.
+        let resolution: () -> Service? = { [self] in
             self.incrementResolutionDepth()
             defer { self.decrementResolutionDepth() }
 


### PR DESCRIPTION
- Add synchronization tests for `Lazy` and `Producer`
- Fix issue of thread safety not enforced for `Lazy` and `Producer`
- Removes need for `SynchronizedResolver` by internalizing usage of the `RecursiveLock`
  - Should be more performant as the synchronization is just done around the final resolution instead of all entry points

Should fix issue https://github.com/Swinject/Swinject/issues/493