### PR TITLE
GraphIdentifier threadsafety optimization & patch interleaving race condition in Lazy resolve

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -225,8 +225,8 @@ extension Container: _Resolver {
         )
 
         if let entry = getEntry(for: key) {
-            let factory = { [weak self] (graphIdentifier: GraphIdentifier?) in
-                let action = { [weak self] in
+            let factory = { [weak self] (graphIdentifier: GraphIdentifier?) -> Any? in
+                let action = { [weak self] () -> Any? in
                     if let graphIdentifier = graphIdentifier {
                         self?.restoreObjectGraph(graphIdentifier)
                     }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -177,6 +177,8 @@ public final class Container {
         behaviors.append(behavior)
     }
 
+    /// Restores the object graph to match the given identifier.
+    /// Not synchronized, use lock to edit safely.
     internal func restoreObjectGraph(_ identifier: GraphIdentifier) {
         currentObjectGraph = identifier
     }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -227,9 +227,9 @@ extension Container: _Resolver {
         if let entry = getEntry(for: key) {
             let factory = { [weak self] (graphIdentifier: GraphIdentifier?) in
                 let action = { [weak self] in
-//                    if let graphIdentifier = graphIdentifier {
-//                        self?.restoreObjectGraph(graphIdentifier)
-//                    }
+                    if let graphIdentifier = graphIdentifier {
+                        self?.restoreObjectGraph(graphIdentifier)
+                    }
                     return self?.resolve(entry: entry, invoker: invoker) as Any?
                 }
                 if self?.synchronized ?? true {

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -227,9 +227,9 @@ extension Container: _Resolver {
         if let entry = getEntry(for: key) {
             let factory = { [weak self] (graphIdentifier: GraphIdentifier?) in
                 let action = { [weak self] in
-                    if let graphIdentifier = graphIdentifier {
-                        self?.restoreObjectGraph(graphIdentifier)
-                    }
+//                    if let graphIdentifier = graphIdentifier {
+//                        self?.restoreObjectGraph(graphIdentifier)
+//                    }
                     return self?.resolve(entry: entry, invoker: invoker) as Any?
                 }
                 if self?.synchronized ?? true {

--- a/Sources/GraphIdentifier.swift
+++ b/Sources/GraphIdentifier.swift
@@ -2,9 +2,24 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
+#if os(iOS) || os(macOS)
 /// Unique identifier of an object graph during a resolution process.
 public struct GraphIdentifier: Identifiable {
     public let id = UUID()
 }
 
 extension GraphIdentifier: Equatable, Hashable {}
+#else
+/// Unique identifier of an object graph during a resolution process.
+public final class GraphIdentifier {}
+
+extension GraphIdentifier: Equatable, Hashable {
+    public static func == (lhs: GraphIdentifier, rhs: GraphIdentifier) -> Bool {
+        return lhs === rhs
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self).hashValue)
+    }
+}
+#endif

--- a/Sources/GraphIdentifier.swift
+++ b/Sources/GraphIdentifier.swift
@@ -3,14 +3,8 @@
 //
 
 /// Unique identifier of an object graph during a resolution process.
-public final class GraphIdentifier {}
-
-extension GraphIdentifier: Equatable, Hashable {
-    public static func == (lhs: GraphIdentifier, rhs: GraphIdentifier) -> Bool {
-        return lhs === rhs
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(self).hashValue)
-    }
+public struct GraphIdentifier: Identifiable {
+    public let id = UUID()
 }
+
+extension GraphIdentifier: Equatable, Hashable {}

--- a/Sources/GraphIdentifier.swift
+++ b/Sources/GraphIdentifier.swift
@@ -2,24 +2,18 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-#if os(iOS) || os(macOS)
+// no universal UUID impl on Linux
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 /// Unique identifier of an object graph during a resolution process.
 public struct GraphIdentifier: Identifiable {
     public let id = UUID()
 }
-
-extension GraphIdentifier: Equatable, Hashable {}
 #else
 /// Unique identifier of an object graph during a resolution process.
-public final class GraphIdentifier {}
-
-extension GraphIdentifier: Equatable, Hashable {
-    public static func == (lhs: GraphIdentifier, rhs: GraphIdentifier) -> Bool {
-        return lhs === rhs
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(self).hashValue)
-    }
+public struct GraphIdentifier: Identifiable {
+    public let id = UInt.random(in: 0..<UInt.max)
 }
 #endif
+
+extension GraphIdentifier: Equatable, Hashable {}

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -35,7 +35,7 @@ public final class GraphStorage: InstanceStorage {
         self.instance = instance
 
         if instances[graph] == nil { instances[graph] = Weak() }
-        instances[graph]?.value = instance as? AnyObject
+        instances[graph]?.value = instance as AnyObject?
     }
 }
 
@@ -63,7 +63,7 @@ public final class WeakStorage: InstanceStorage {
 
     public var instance: Any? {
         get { return _instance.value }
-        set { _instance.value = newValue as? AnyObject }
+        set { _instance.value = newValue as AnyObject? }
     }
 
     public init() {}

--- a/Sources/InstanceStorage.swift
+++ b/Sources/InstanceStorage.swift
@@ -18,7 +18,7 @@ extension InstanceStorage {
 
 /// Persists storage during the resolution of the object graph
 public final class GraphStorage: InstanceStorage {
-    private var instances = [GraphIdentifier: Weak<Any>]()
+    private var instances = [GraphIdentifier: Weak]()
     public var instance: Any?
 
     public init() {}
@@ -35,7 +35,7 @@ public final class GraphStorage: InstanceStorage {
         self.instance = instance
 
         if instances[graph] == nil { instances[graph] = Weak() }
-        instances[graph]?.value = instance
+        instances[graph]?.value = instance as? AnyObject
     }
 }
 
@@ -59,11 +59,11 @@ public final class TransientStorage: InstanceStorage {
 /// Does not persist value types.
 /// Persists reference types as long as there are strong references to given instance.
 public final class WeakStorage: InstanceStorage {
-    private var _instance = Weak<Any>()
+    private var _instance = Weak()
 
     public var instance: Any? {
         get { return _instance.value }
-        set { _instance.value = newValue }
+        set { _instance.value = newValue as? AnyObject }
     }
 
     public init() {}
@@ -106,25 +106,6 @@ public final class CompositeStorage: InstanceStorage {
     }
 }
 
-private class Weak<Wrapped> {
-    private weak var object: AnyObject?
-
-    #if os(Linux)
-        var value: Wrapped? {
-            get {
-                guard let object = object else { return nil }
-                return object as? Wrapped
-            }
-            set { object = newValue.flatMap { $0 as? AnyObject } }
-        }
-
-    #else
-        var value: Wrapped? {
-            get {
-                guard let object = object else { return nil }
-                return object as? Wrapped
-            }
-            set { object = newValue as AnyObject? }
-        }
-    #endif
+private class Weak {
+    weak var value: AnyObject?
 }

--- a/Sources/InstanceWrapper.swift
+++ b/Sources/InstanceWrapper.swift
@@ -14,13 +14,13 @@ public final class Lazy<Service>: InstanceWrapper {
     static var wrappedType: Any.Type { return Service.self }
 
     private let factory: (GraphIdentifier?) -> Any?
-//    private var graphIdentifier: GraphIdentifier?
+    private var graphIdentifier: GraphIdentifier?
     private weak var container: Container?
 
     init?(inContainer container: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
         guard let factory = factory else { return nil }
         self.factory = factory
-//        self.graphIdentifier = container.currentObjectGraph
+        graphIdentifier = container.currentObjectGraph
         self.container = container
     }
 
@@ -38,7 +38,7 @@ public final class Lazy<Service>: InstanceWrapper {
     }
 
     private func makeInstance() -> Service? {
-        return factory(nil) as? Service
+        factory(graphIdentifier) as? Service
     }
 }
 

--- a/Sources/InstanceWrapper.swift
+++ b/Sources/InstanceWrapper.swift
@@ -14,13 +14,13 @@ public final class Lazy<Service>: InstanceWrapper {
     static var wrappedType: Any.Type { return Service.self }
 
     private let factory: (GraphIdentifier?) -> Any?
-    private let graphIdentifier: GraphIdentifier?
+//    private var graphIdentifier: GraphIdentifier?
     private weak var container: Container?
 
     init?(inContainer container: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
         guard let factory = factory else { return nil }
         self.factory = factory
-        graphIdentifier = container.currentObjectGraph
+//        self.graphIdentifier = container.currentObjectGraph
         self.container = container
     }
 
@@ -38,7 +38,7 @@ public final class Lazy<Service>: InstanceWrapper {
     }
 
     private func makeInstance() -> Service? {
-        return factory(graphIdentifier) as? Service
+        return factory(nil) as? Service
     }
 }
 

--- a/Sources/InstanceWrapper.swift
+++ b/Sources/InstanceWrapper.swift
@@ -14,7 +14,7 @@ public final class Lazy<Service>: InstanceWrapper {
     static var wrappedType: Any.Type { return Service.self }
 
     private let factory: (GraphIdentifier?) -> Any?
-    private var graphIdentifier: GraphIdentifier?
+    private let graphIdentifier: GraphIdentifier?
     private weak var container: Container?
 
     init?(inContainer container: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -98,11 +98,12 @@ class SynchronizedResolverTests: XCTestCase {
             graphs.insert(($0 as! Container).currentObjectGraph!)
             return Dog()
         }
+        .inObjectScope(.container)
 
         let synchronized = container.synchronize()
 
         onMultipleThreads {
-            let lazy = synchronized.resolve(Provider<Animal>.self)
+            let lazy = synchronized.resolve(Lazy<Animal>.self)
             _ = lazy?.instance
         }
 

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -130,6 +130,7 @@ class SynchronizedResolverTests: XCTestCase {
         }
     }
 
+    #if os(iOS) || os(macOS)
     func testSynchronizedResolverSafelyDereferencesLazyTypes() {
         var graphs = Set<GraphIdentifier>()
         let container = Container()
@@ -155,6 +156,7 @@ class SynchronizedResolverTests: XCTestCase {
             }
         }
     }
+    #endif
 }
 
 private final class Counter {

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -130,7 +130,6 @@ class SynchronizedResolverTests: XCTestCase {
         }
     }
 
-    #if os(iOS) || os(macOS)
     func testSynchronizedResolverSafelyDereferencesLazyTypes() {
         var graphs = Set<GraphIdentifier>()
         let container = Container()
@@ -156,7 +155,6 @@ class SynchronizedResolverTests: XCTestCase {
             }
         }
     }
-    #endif
 }
 
 private final class Counter {

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -147,6 +147,9 @@ class SynchronizedResolverTests: XCTestCase {
                 // Lazy will be strongly referenced and then DE-referenced
                 // which triggers a strong retain cycle on the GraphIdentifier
                 // which may be simultaneously deallocated on a separate thread
+                //
+                // But, since the build with this test uses struct type for
+                // the GraphIdentifier, this test will succeed. 🎉
                 let lazy = synchronized.resolve(Lazy<Animal>.self)
                 _ = lazy?.instance
             }

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -98,12 +98,11 @@ class SynchronizedResolverTests: XCTestCase {
             graphs.insert(($0 as! Container).currentObjectGraph!)
             return Dog()
         }
-        .inObjectScope(.container)
 
         let synchronized = container.synchronize()
 
         onMultipleThreads {
-            let lazy = synchronized.resolve(Lazy<Animal>.self)
+            let lazy = synchronized.resolve(Provider<Animal>.self)
             _ = lazy?.instance
         }
 


### PR DESCRIPTION
We encountered a bizarre error in an async context; this PR offers a solution to two problems. (A topic of note here is that the `GraphIdentifier` is a _class_. We will come back to this later).

- GraphIdentifier dereference crash, e.g. `EXC_BAD_ACCESS: KERN_INVALID_ADDRESS: Attempted to dereference garbage pointer`
- Race condition wherein an async call to `Lazy.instance` could acquire the lock, set the graph identifier, release the lock, then **re-acquire** the lock and begin resolving. In between the lock release/acquisition of one `.instance` call, another `.instance` call could update the GraphIdentifier before the first thread could call `resolve` and re-acquire the lock. Can results in unexpected behaviour.

## Synchronization
Synchronizing a container will emit a child which ensures that any async calls to `resolve(…)` should happen sequentially and never concurrently (or more precisely, for the logic within).

One line here is quite interesting:
![CleanShot 2022-10-15 at 13 07 49@2x](https://user-images.githubusercontent.com/95654268/195999161-ed460384-c803-4f9f-8dab-ce7e1689d40a.jpg)

It happens within the sync context, so it should be safe. However, there is one Swinject object that _also_ contains a graph identifier reference. That is Lazy.

![CleanShot 2022-10-15 at 12 37 11@2x](https://user-images.githubusercontent.com/95654268/195997881-5000283e-bb25-4758-a991-05875c727665.jpg)

![CleanShot 2022-10-15 at 12 39 05@2x](https://user-images.githubusercontent.com/95654268/195997959-3603c66e-dd95-4c7d-a0a2-09daa5ff4fa9.jpg)

A Lazy property can be held by any class. Once that class is dereferenced/deallocated so are its children, in this case the `ObjectIdentifier` being one of them.

Critically, **we have no control over when a Lazy property (and its GraphIdentifier ref) might be released**.

```
deinit {
    container?.lock.sync {
        // THIS AVOIDS THE DEREFERENCE CRASH
        self.graphIdentifier = nil
    }
}
```
- To further my point, the above line entirely prevents the crash when added to the `Lazy` type.

## Solution

This one fairly simple and results meets expectations for GraphIdentifier behaviour. It should be an Identifiable struct, the performance tradeoffs here are negligible: a smidge costlier to create, but faster to pass by value (requires no ARC calls).

### Some debug artifacts…
- Swift ARC concurrency crashes are really hard to debug…so in this case it helps to have an extra pair of eyes and some compiler help
- [neat Swift forum thread on `@_assemblyVision`](https://forums.swift.org/t/psa-compiler-optimisation-remarks/54152)

![CleanShot 2022-10-15 at 12 26 06@2x](https://user-images.githubusercontent.com/95654268/195997439-68928c41-0c43-407b-9d45-95c118e31b48.jpg)

![CleanShot 2022-10-15 at 12 42 57@2x](https://user-images.githubusercontent.com/95654268/195998126-43a14f4e-2362-401a-be30-bfa03ca9a8f3.jpg)
![CleanShot 2022-10-15 at 12 44 26@2x](https://user-images.githubusercontent.com/95654268/195998177-dfbed399-10f9-482a-a9b1-eb26acd3e881.jpg)
