### PR TITLE
remove useless [unowned self]

### DIFF
--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -25,7 +25,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
     internal weak var container: Container?
 
     internal var objectScope: ObjectScopeProtocol = ObjectScope.graph
-    internal lazy var storage: InstanceStorage = { [unowned self] in
+    internal lazy var storage: InstanceStorage = {
         self.objectScope.makeStorage()
     }()
 


### PR DESCRIPTION
as closures are @noescape by default and don't retain 'self' since Swift version 3

More info: 
https://stackoverflow.com/questions/38141298/lazy-initialisation-and-retain-cycle
https://github.com/apple/swift-evolution/blob/main/proposals/0103-make-noescape-default.md
https://michael-kiley.medium.com/why-your-lazy-vars-arent-creating-strong-reference-cycles-in-ios-d512ff2c9403
<img width="710" alt="Screenshot 2023-03-10 at 14 35 44" src="https://user-images.githubusercontent.com/1945749/224294210-bacc472d-dbda-40dd-99da-626cb248f546.png">
