### PR TITLE
Make synchronous reads and writes to the container safe

### DIFF
--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © 2023 Swinject Contributors. All rights reserved.
+//
+
+import Foundation
+
+internal final class ReadWriteLock {
+    private var lock: pthread_rwlock_t = pthread_rwlock_t()
+
+    init() {
+        pthread_rwlock_init(&lock, nil)
+    }
+
+    deinit {
+        pthread_rwlock_destroy(&lock)
+    }
+
+    @inlinable public func read<T>(_ block: () throws -> T) rethrows -> T {
+        pthread_rwlock_rdlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+
+        return try block()
+    }
+
+    @inlinable public func write<T>(_ block: () throws -> T) rethrows -> T {
+        pthread_rwlock_wrlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+
+        return try block()
+    }
+}

--- a/Sources/ThreadSafeDictionary.swift
+++ b/Sources/ThreadSafeDictionary.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright © 2023 Swinject Contributors. All rights reserved.
+//
+import Foundation
+
+internal final class ThreadSafeDictionary<KeyType: Hashable, ValueType> {
+    private var internalDictionary = [KeyType: ValueType]()
+
+    private let lock = ReadWriteLock()
+
+    // MARK: - Initializers
+
+    public init(dictionary: [KeyType: ValueType]? = nil) {
+        if let dictionary = dictionary {
+            lock.write {
+                self.internalDictionary = dictionary
+            }
+        }
+    }
+
+    // MARK: - Functions
+
+    public subscript(key: KeyType) -> ValueType? {
+        get {
+            return lock.read { self.internalDictionary[key] }
+        }
+
+        set {
+            lock.write {
+                self.internalDictionary[key] = newValue
+            }
+        }
+    }
+    
+    public subscript(key: KeyType, default defaultValue: @autoclosure () -> ValueType) -> ValueType? {
+        get {
+            return lock.read { self.internalDictionary[key, default: defaultValue()] }
+        }
+
+        set {
+            lock.write {
+                self.internalDictionary[key] = newValue
+            }
+        }
+    }
+
+    public func forEachRead(_ block: ((key: KeyType, value: ValueType)) -> Void) {
+        lock.read {
+            self.internalDictionary.forEach(block)
+        }
+    }
+    
+    public func forEachWrite(_ block: ((key: KeyType, value: ValueType)) -> Void) {
+        lock.write {
+            self.internalDictionary.forEach(block)
+        }
+    }
+
+    public func map<T>(_ transform: ((key: KeyType, value: ValueType)) throws -> T) rethrows -> [T] {
+        try lock.read {
+            try self.internalDictionary.map(transform)
+        }
+    }
+
+    public func removeAll() {
+        lock.write {
+            self.internalDictionary.removeAll()
+        }
+    }
+}


### PR DESCRIPTION
The `services` parameter is not thread safe. Concurrent reads are safe, but concurrent reads with writes happening at the same time are not. This adds a read/write lock around it, making reads synchronous and safe, but writes block to ensure safety.

Resolves #539