### PR TITLE
Adds privacy manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
The privacy manifest discussion doesn't apply to Swinject since this library does not engage in any of the relevant activities. Swinject does not have a way neither ever intends to use data on disk / or any kind of data linked to a user.

Our manifest can just specify that Swinject doesn't handle user data or make the special listed API calls.
- #549 
- #542 

More info here.
- [Privacy Manifest Files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files)