### PR TITLE
Undo graph restoration once Lazy wrapper resolves its local hierarchy

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -250,6 +250,8 @@ extension Container: _Resolver {
         if let entry = getEntry(for: key) {
             let factory = { [weak self] (graphIdentifier: GraphIdentifier?) -> Any? in
                 let action = { [weak self] () -> Any? in
+                    let originGraph = self?.currentObjectGraph
+                    defer { originGraph.map { self?.restoreObjectGraph($0) } }
                     if let graphIdentifier = graphIdentifier {
                         self?.restoreObjectGraph(graphIdentifier)
                     }

--- a/Tests/SwinjectTests/Circularity.swift
+++ b/Tests/SwinjectTests/Circularity.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import Swinject
 
 // MARK: Circular dependency of two objects
 
@@ -69,3 +70,35 @@ internal class DDependingOnBC: D {
 internal class CDependingOnWeakB: C {
     weak var b: B?
 }
+
+internal protocol LazyParentProtocol {
+    var child1: LazyChildProtocol { get }
+    var child2: LazyChildProtocol { get }
+}
+internal protocol LazyChildProtocol: AnyObject {
+    var lazy: Lazy<LazilyResolvedProtocol> { get }
+}
+internal protocol LazySingletonProtocol {
+    var lazy: Lazy<LazilyResolvedProtocol> { get }
+}
+internal protocol LazilyResolvedProtocol: AnyObject { }
+
+internal class LazyParent: LazyParentProtocol {
+    let child1: LazyChildProtocol
+    let child2: LazyChildProtocol
+
+    init(child1: LazyChildProtocol, child2: LazyChildProtocol) {
+        self.child1 = child1
+        self.child2 = child2
+    }
+}
+
+internal class LazyChild: LazyChildProtocol, LazySingletonProtocol {
+    let lazy: Lazy<LazilyResolvedProtocol>
+
+    init(lazy: Lazy<LazilyResolvedProtocol>) {
+        self.lazy = lazy
+    }
+}
+
+internal class LazilyResolved: LazilyResolvedProtocol { }


### PR DESCRIPTION
Fixes this possible edge case.
1. Container begins to resolve complex object.
2. Complex object contains multiple graph scoped items, lazily wrapped.
3. A lazy instance is accessed early, before the graph resolution has completed.
4. Lazy wrapper restores the stored graph identifier.
5. Container continues resolution using the incorrect graph identifier for _this_ resolution.