### PR TITLE
Added Privacy manifest in resource bundles

### DIFF
--- a/Swinject.podspec
+++ b/Swinject.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = 'Swinject Contributors'
   s.source           = { :git => "https://github.com/Swinject/Swinject.git", :tag => s.version.to_s }
+  s.resource_bundles = { 'Swinject' => ['PrivacyInfo.xcprivacy'] }
 
   s.swift_version    = '5.0'
   s.source_files     = 'Sources/**/*.swift'


### PR DESCRIPTION
Hello!
PrivacyInfo not declared in Swinject.podspec as resource bundles. So when I use last version of Swinject (2.8.5), there is no manifest in pod files.
This PR has a little fix for it, review it please
https://guides.cocoapods.org/syntax/podspec.html#resource_bundles