### PR TITLE
fix: add NSPrivacyCollectedDataTypes and NSPrivacyAccessedAPITypes to Privacy manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue
Issue related to missing key in privacy manfiest: Missing an expected key: 'NSPrivacyCollectedDataTypes'
## Description
This PR adds the collected data and accessed API sections in the privacy manifests.
This PR also fixes a problem with generating the privacy manifest report, without this PR, the privacy report shows errors expecting the CollectedDataType key to exist:
<img width="618" alt="Снимок экрана 2024-04-17 в 19 59 40" src="https://github.com/Swinject/Swinject/assets/78110873/4dbef5cf-1082-4c74-9695-ed2c5ac26036">

To generate a privacy report, Archive the app which consumes the library, and then in Xcode -> Window -> Organizer -> Under Archives, right click on the archive -> Generate Privacy Report. The privacy report only shows tracking related information, thus with this change the privacy report will be an empty file.

