### PR TITLE
Streamline Container synchronization logic

### DIFF
--- a/Sources/Container.TypeForwarding.swift
+++ b/Sources/Container.TypeForwarding.swift
@@ -25,7 +25,9 @@ extension Container {
             name: name,
             option: nil
         )
-        services[key] = service
-        behaviors.forEach { $0.container(self, didRegisterType: type, toService: service, withName: name) }
+        syncIfEnabled {
+            services[key] = service
+            behaviors.forEach { $0.container(self, didRegisterType: type, toService: service, withName: name) }
+        }
     }
 }

--- a/Sources/RecursiveLock.swift
+++ b/Sources/RecursiveLock.swift
@@ -4,12 +4,100 @@
 
 import Foundation
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+/// `os_unfair_lock_recursive` is, for some reason, a private-API.
+///
+/// `RecursiveLock` is a fair, recursive lock where acquisition order is guaranteed and recursion is permitted.
+///
+/// Based on readings:
+/// - https://www.mikeash.com/pyblog/friday-qa-2017-10-27-locks-thread-safety-and-swift-2017-edition.html
+/// - https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Atomic.swift
+/// - https://serhiybutz.medium.com/swift-mutex-benchmark-b21ee293d9ad
+///
+/// Class-type paired with pointer-use guarantees address stability.
+public final class RecursiveLock {
+    // MARK: Lifecycle
+
+    public init() {
+        mutex = .allocate(capacity: 1)
+        mutex.initialize(to: pthread_mutex_t())
+
+        let attr = UnsafeMutablePointer<pthread_mutexattr_t>.allocate(capacity: 1)
+        attr.initialize(to: pthread_mutexattr_t())
+        pthread_mutexattr_init(attr)
+        pthread_mutexattr_settype(attr, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutexattr_setpolicy_np(attr, PTHREAD_MUTEX_POLICY_FIRSTFIT_NP)
+
+        defer {
+            pthread_mutexattr_destroy(attr)
+            attr.deinitialize(count: 1)
+            attr.deallocate()
+        }
+
+        pthread_mutex_init(mutex, attr)
+    }
+
+    deinit {
+        let status = pthread_mutex_destroy(mutex)
+        assert(status == 0, "Unlock the lock before destroying it")
+
+        mutex.deinitialize(count: 1)
+        mutex.deallocate()
+    }
+
+    // MARK: Internal
+
+    internal func lock() {
+        let status = pthread_mutex_lock(mutex)
+        switch status {
+        case 0:
+            break
+        case EDEADLK:
+            fatalError("Lock failed, would cause deadlock")
+        default:
+            fatalError("Could not lock")
+        }
+    }
+
+    internal func unlock() {
+        let status = pthread_mutex_unlock(mutex)
+        switch status {
+        case 0:
+            break
+        case EPERM:
+            fatalError("Cannot unlock when another thread owns the lock!")
+        default:
+            fatalError("Could not unlock")
+        }
+    }
+
+    // MARK: Private
+
+    private let mutex: UnsafeMutablePointer<pthread_mutex_t>
+}
+#else
 internal final class RecursiveLock {
     private let lock = NSRecursiveLock()
 
-    func sync<T>(action: () -> T) -> T {
+    func lock() {
         lock.lock()
-        defer { lock.unlock() }
-        return action()
+    }
+
+    func unlock() {
+        lock.unlock()
+    }
+}
+#endif
+
+extension RecursiveLock {
+    /// Guarantee exclusive thread access to certain logic.
+    ///
+    /// Claims ownership over this lock within the scope of the closure,
+    /// during which this thread owns this lock. Nested `atomic` calls
+    /// on the same thread are permitted.
+    @discardableResult
+    func sync<T>(_ block: () throws -> (T)) rethrows -> T {
+        lock(); defer { unlock() }
+        return try block()
     }
 }

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		4D667425CB08BF894C1A78AA /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D8BA4B04A5F517AF663DCE /* Behavior.swift */; };
 		5010597DD8C25E6684C8087E /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5922B783F35F436C528594C1 /* Assembly.swift */; };
 		513BDFB32DCE5B048672C33D /* ServiceEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76238B6105E2E443A94CE595 /* ServiceEntry.swift */; };
+		516EB7F82BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */; };
+		516EB7F92BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */; };
+		516EB7FA2BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */; };
+		516EB7FB2BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */; };
 		51F2541C2BC5A2EF003E3BCD /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2541A2BC5A2EF003E3BCD /* ReadWriteLock.swift */; };
 		51F2541D2BC5A2EF003E3BCD /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2541A2BC5A2EF003E3BCD /* ReadWriteLock.swift */; };
 		51F2541E2BC5A2EF003E3BCD /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2541A2BC5A2EF003E3BCD /* ReadWriteLock.swift */; };
@@ -312,6 +316,7 @@
 		47328731EED63322AD76FB3A /* Circularity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Circularity.swift; sourceTree = "<group>"; };
 		4744C3ABBA9A8A585C726883 /* ContainerTests.DebugHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTests.DebugHelper.swift; sourceTree = "<group>"; };
 		515B0F492BC9AF5D00C4E24F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTests.Speed.swift; sourceTree = "<group>"; };
 		51F2541A2BC5A2EF003E3BCD /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		51F2541B2BC5A2EF003E3BCD /* ThreadSafeDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeDictionary.swift; sourceTree = "<group>"; };
 		54FFC812F14E9976208B644F /* ServiceEntry.TypeForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEntry.TypeForwarding.swift; sourceTree = "<group>"; };
@@ -415,6 +420,7 @@
 				5FCE820EE05C206E34CEF068 /* ContainerTests.CustomStringConvertible.swift */,
 				4744C3ABBA9A8A585C726883 /* ContainerTests.DebugHelper.swift */,
 				46A04FC6931B56743E4B7D63 /* ContainerTests.GraphCaching.swift */,
+				516EB7F72BDC124100FF78D2 /* ContainerTests.Speed.swift */,
 				19726C4D2E8898E5C05A5E38 /* ContainerTests.swift */,
 				BBDE1F7FCBF0C61DE0BA3ED2 /* ContainerTests.TypeForwarding.swift */,
 				077047532310E42432E94D83 /* EmploymentAssembly.swift */,
@@ -854,6 +860,7 @@
 				1C1C0CB3F19349057B4FBDE1 /* BasicAssembly.swift in Sources */,
 				235DD35BC7B8CE15BA46A677 /* BehaviorFakes.swift in Sources */,
 				F355D8940486AF9DE89DD22E /* Circularity.swift in Sources */,
+				516EB7F82BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */,
 				374D3B4A2A2163726B4E55BC /* ContainerTests.Arguments.swift in Sources */,
 				C578E997A0076FB320475132 /* ContainerTests.Behavior.swift in Sources */,
 				4C06628453523BB76531404F /* ContainerTests.Circularity.swift in Sources */,
@@ -886,6 +893,7 @@
 				9ECC88CB09E13FD179A1ED8E /* BasicAssembly.swift in Sources */,
 				FF9DCB0AB20B0DBBE79451BB /* BehaviorFakes.swift in Sources */,
 				F82A2357F3C86D24E1E1D712 /* Circularity.swift in Sources */,
+				516EB7F92BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */,
 				96E113959C6AF4C512C95B0F /* ContainerTests.Arguments.swift in Sources */,
 				31C021202AAC21C893F790A9 /* ContainerTests.Behavior.swift in Sources */,
 				DAB7F0C574E1C33C92C455A5 /* ContainerTests.Circularity.swift in Sources */,
@@ -918,6 +926,7 @@
 				6443FB8C5B3DD95740287398 /* BasicAssembly.swift in Sources */,
 				0CAD0368F908D3D285C6A9A9 /* BehaviorFakes.swift in Sources */,
 				69A27AA36C90A4D4A5FDDEFC /* Circularity.swift in Sources */,
+				516EB7FB2BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */,
 				56F7004F323632D46B60D750 /* ContainerTests.Arguments.swift in Sources */,
 				BCDBFF75F368C980B6DA4BFE /* ContainerTests.Behavior.swift in Sources */,
 				88D3B360E738AE936A4C3FC1 /* ContainerTests.Circularity.swift in Sources */,
@@ -950,6 +959,7 @@
 				5D17DB72B4986D174D69135B /* BasicAssembly.swift in Sources */,
 				1BA2596EFB6E7BF4D46E3C9D /* BehaviorFakes.swift in Sources */,
 				0E5336910C7B0A00E588940E /* Circularity.swift in Sources */,
+				516EB7FA2BDC124100FF78D2 /* ContainerTests.Speed.swift in Sources */,
 				A87B2787A32FAA3254700F90 /* ContainerTests.Arguments.swift in Sources */,
 				12984E4749F7C882055D380F /* ContainerTests.Behavior.swift in Sources */,
 				0CC89E82308CF2FFF0CCC267 /* ContainerTests.Circularity.swift in Sources */,

--- a/Tests/SwinjectTests/ContainerTests.Speed.swift
+++ b/Tests/SwinjectTests/ContainerTests.Speed.swift
@@ -1,0 +1,54 @@
+//
+//  Copyright © 2024 Swinject Contributors. All rights reserved.
+//
+
+import XCTest
+@testable import Swinject
+
+/// Not a perfect way to measure speed improvements, especially with all the different hardware that will be running
+/// this test, but good to run before/after changes to see changes.
+@available(iOS 13.0, *)
+class ContainerSpeedTests: XCTestCase {
+    var container: Container!
+
+    override func setUpWithError() throws {
+        container = Container()
+
+        container.register(Animal.self) { _ in Cat() }
+        container.register(Animal.self) { _, arg in Cat(name: arg) }
+        container.register(Animal.self) { _, arg1, arg2 in Cat(name: arg1, sleeping: arg2) }
+    }
+
+    // MARK: General speed test, ran locally for testing purposes
+
+    func testContainerDefaultResolvesByArguments() {
+        let measureOptions = XCTMeasureOptions()
+        measureOptions.iterationCount = 1
+
+        measure(options: measureOptions) {
+            container.resolveCats()
+        }
+    }    
+
+    func testContainerSyncResolvesByArguments() {
+        container = container.synchronize() as? Container
+
+        let measureOptions = XCTMeasureOptions()
+        measureOptions.iterationCount = 1
+
+        measure(options: measureOptions) {
+            container.resolveCats()
+        }
+    }
+}
+
+fileprivate extension Container {
+    func resolveCats() {
+        for _ in 0..<500_000 {
+            _ = resolve(Animal.self) as? Cat
+            _ = resolve(Animal.self, argument: "Mimi") as? Cat
+            let lazy = resolve(Lazy<Animal>.self, arguments: "Mew", true)
+            _ = lazy?.instance as? Cat
+        }
+    }
+}

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -70,7 +70,7 @@ class SynchronizedResolverTests: XCTestCase {
     
     func testSynchronizedResolverSynchronousReadsWrites() {
         let iterationCount = 3_000
-        let container = Container()
+        let container = Container().synchronize() as! Container
         let registerExpectation = expectation(description: "register")
         let resolveExpectations = (0..<iterationCount).map { expectation(description: String(describing: $0)) }
         let resolutionLock = NSLock()
@@ -86,7 +86,7 @@ class SynchronizedResolverTests: XCTestCase {
         
         DispatchQueue.global(qos: .background).async {
             DispatchQueue.concurrentPerform(iterations: iterationCount) { (index) in
-                _ = container.synchronize().resolve(Animal.self)
+                _ = container.resolve(Animal.self)
                 resolutionLock.lock()
                 resolveExpectations[index].fulfill()
                 resolutionLock.unlock()


### PR DESCRIPTION
- Threading-safety covers every public entry point to the Container
- Added some performance tests in case anybody wants to try tackling efficiency locally
- Introduced a first-fit pthread based recursive-lock
- Reduced # of lock layers, tests pass ✅ 