### PR TITLE
Fix up test assertions

### DIFF
--- a/Tests/SwinjectTests/ContainerTests.TypeForwarding.swift
+++ b/Tests/SwinjectTests/ContainerTests.TypeForwarding.swift
@@ -140,7 +140,15 @@ class ContainerTests_TypeForwarding: XCTestCase {
 
     func testContainerResolvesOptionalToNilWhenWrappedTypeIsNotRegistered() {
         let optionalDog = container.resolve(Dog?.self)
-        XCTAssertNotNil(optionalDog)
+        // The type of `optionalDog` is `Dog??` i.e. `Optional<Optional<Dog>>`
+        switch optionalDog {
+        case .some(.none):
+            // Test pass
+            break
+        default:
+            // Any other value is incorrect
+            XCTFail()
+        }
     }
 
     func testContainerResolvesOptionalWithName() {
@@ -152,8 +160,15 @@ class ContainerTests_TypeForwarding: XCTestCase {
     func testContainerResolvesOptionalToNilWithWrongName() {
         container.register(Dog.self, name: "Hachi") { _ in Dog() }
         let optionalDog = container.resolve(Dog?.self, name: "Mimi")
-        XCTAssertNil(optionalDog ?? nil)
-        XCTAssertNotNil(optionalDog)
+        // The type of `optionalDog` is `Dog??` i.e. `Optional<Optional<Dog>>`
+        switch optionalDog {
+        case .some(.none):
+            // Test pass
+            break
+        default:
+            // Any other value is incorrect
+            XCTFail()
+        }
     }
 
     func testContainerResolvesOptionalWithArguments() {


### PR DESCRIPTION
These were producing warnings in Xcode 15.3 about the double Optional: `Expression implicitly coerced from 'Dog??' to 'Any?’`

Now explicitly matching the expected output.