### PR TITLE
Fix the broken links to Funq in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The DI container features of Swinject are inspired by:
 
 and highly inspired by:
 
-- [Funq](http://funq.codeplex.com) - [Daniel Cazzulino](http://www.codeplex.com/site/users/view/dcazzulino) and [the project team](http://funq.codeplex.com/team/view).
+- [Funq](https://github.com/kzu/funq) - [Daniel Cazzulino](https://github.com/kzu).
 
 ## License
 


### PR DESCRIPTION
The links to the original repository of Funq were broken as [CodePlex](https://en.wikipedia.org/wiki/CodePlex) hosted by Microsoft has been discontinued.

I replaced the broken links with the GitHub repository as the author ported the repository there.