### PR TITLE
Exposes object graph

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -239,7 +239,7 @@ extension Container: _Resolver {
             let key = ServiceKey(serviceType: Service.self, argumentsType: Arguments.self, name: name, option: option)
 
             if key == Self.graphIdentifierKey {
-                return currentObjectGraph as! Service?
+                return currentObjectGraph as? Service
             }
 
             if let entry = getEntry(for: key) {

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.8</string>
+	<string>2.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Swinject.podspec
+++ b/Swinject.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Swinject"
-  s.version          = "2.8.8"
+  s.version          = "2.9.0"
   s.summary          = "Dependency injection framework for Swift"
   s.description      = "Swinject is a dependency injection framework for Swift, to manage the dependencies of types in your system."
 

--- a/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
+++ b/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
@@ -116,6 +116,36 @@ class ContainerTests_GraphCaching: XCTestCase {
 
         XCTAssert(dog1 === dog2)
     }
+
+    func testContainerGraphScopeResolvesToNil() {
+        let graphScope = container.resolve(GraphIdentifier.self)
+        XCTAssertNil(graphScope)
+    }
+
+    func testContainerResolvesGraphScopeIfAvailable() {
+        var graph: GraphIdentifier?
+        container.register(Dog.self) {
+            graph = ($0 as? Container)?.resolve(GraphIdentifier.self)
+            return Dog()
+        }
+        let _ = container.resolve(Dog.self)!
+        XCTAssertNotNil(graph)
+    }
+
+    func testContainerManualScopeSetResolvesGraph() {
+        var graph: GraphIdentifier!
+        container.register(Dog.self) {
+            graph = ($0 as? Container)?.resolve(GraphIdentifier.self)
+            return Dog()
+        }.inObjectScope(.graph)
+
+        let dog1 = container.resolve(Dog.self)!
+        var dog2: Dog!
+        container.withObjectGraph(graph) {
+            dog2 = $0.resolve(Dog.self)!
+        }
+        XCTAssert(dog1 === dog2)
+    }
 }
 
 private class StorageSpy: InstanceStorage {

--- a/Tests/SwinjectTests/Info.plist
+++ b/Tests/SwinjectTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.8</string>
+	<string>2.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
At Faire we use a custom property wrapper `@Resolved` to make Swinject calls (hopefully we can land it in this repo soon), and had to make some significant performance trade-offs to cache the GraphIdentifier without it being properly exposed (involved a workaround using the Lazy wrapper).

This one method & a simple ServiceKey check won't cause any change in Swinject native performance but will permit a few powerful use cases. :)