### PR TITLE
Fix withObjectGraph losing scope

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -210,8 +210,12 @@ public final class Container {
     public func withObjectGraph<T>(_ identifier: GraphIdentifier, closure: (Container) throws -> T) rethrows -> T {
         try syncIfEnabled {
             let graphIdentifier = currentObjectGraph
-            defer { self.currentObjectGraph = graphIdentifier }
+            defer { 
+                self.currentObjectGraph = graphIdentifier
+                decrementResolutionDepth()
+            }
             self.currentObjectGraph = identifier
+            incrementResolutionDepth()
             return try closure(self)
         }
     }

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.9.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Swinject.podspec
+++ b/Swinject.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Swinject"
-  s.version          = "2.9.0"
+  s.version          = "2.9.1"
   s.summary          = "Dependency injection framework for Swift"
   s.description      = "Swinject is a dependency injection framework for Swift, to manage the dependencies of types in your system."
 

--- a/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
+++ b/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
@@ -141,10 +141,13 @@ class ContainerTests_GraphCaching: XCTestCase {
 
         let dog1 = container.resolve(Dog.self)!
         var dog2: Dog!
+        var dog3: Dog!
         container.withObjectGraph(graph) {
             dog2 = $0.resolve(Dog.self)!
+            dog3 = $0.resolve(Dog.self)!
         }
         XCTAssert(dog1 === dog2)
+        XCTAssert(dog2 === dog3)
     }
 }
 

--- a/Tests/SwinjectTests/Info.plist
+++ b/Tests/SwinjectTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.9.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
If running this method with a depth of 0 (no ongoing resolve) then it would simply reset scope with every resolve.