### PR TITLE
Add Container registration functions for @MainActor factories

### DIFF
--- a/Sources/Container.MainActor.erb
+++ b/Sources/Container.MainActor.erb
@@ -1,0 +1,82 @@
+//
+//  Copyright © 2024 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Container.MainActor.swift is generated from Container.MainActor.erb by ERB.
+// Do NOT modify Container.MainActor.swift directly.
+// Instead, modify Container.MainActor.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+<% arg_count = 9 %>
+import Foundation
+
+// MARK: - MainActor registration
+@available(iOS 13.0, macOS 10.15, *)
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a ``Resolver`` to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { r in
+            MainActor.assumeIsolated {
+                return mainActorFactory(r)
+            }
+        }
+    }
+}
+
+// MARK: - MainActor registration with Arguments
+@available(iOS 13.0, macOS 10.15, *)
+extension Container {
+<% (1..arg_count).each do |i| %>
+<%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
+<%   arg_names = (1..i).map { |n| "arg#{n}" }.join(", ") %>
+<%   arg_parameters = (1..i).map { |n| "arg#{n}: Arg#{n}" }.join(", ") %>
+<%   arg_description = i == 1 ? "#{i} argument" : "#{i} arguments" %>
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, <%= arg_types %>>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, <%= arg_types %>) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, <%= arg_parameters %>) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, <%= arg_names %>)
+            }
+        }
+    }
+
+<% end %>
+}

--- a/Sources/Container.MainActor.swift
+++ b/Sources/Container.MainActor.swift
@@ -1,0 +1,283 @@
+//
+//  Copyright © 2024 Swinject Contributors. All rights reserved.
+//
+
+//
+// NOTICE:
+//
+// Container.MainActor.swift is generated from Container.MainActor.erb by ERB.
+// Do NOT modify Container.MainActor.swift directly.
+// Instead, modify Container.MainActor.erb and run `script/gencode` at the project root directory to generate the code.
+//
+
+import Foundation
+
+// MARK: - MainActor registration
+@available(iOS 13.0, macOS 10.15, *)
+extension Container {
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a ``Resolver`` to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { r in
+            MainActor.assumeIsolated {
+                return mainActorFactory(r)
+            }
+        }
+    }
+}
+
+// MARK: - MainActor registration with Arguments
+@available(iOS 13.0, macOS 10.15, *)
+extension Container {
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+            }
+        }
+    }
+
+}

--- a/Tests/SwinjectTests/ContainerTests.MainActor.swift
+++ b/Tests/SwinjectTests/ContainerTests.MainActor.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright © 2024 Swinject Contributors. All rights reserved.
+//
+
+import XCTest
+@testable import Swinject
+
+class ContainerTests_MainActor: XCTestCase {
+
+    private let container = Container()
+
+    @MainActor
+    func testRegistersMainActorFactory() {
+        container.register(MainAnimal.self) { @MainActor _ in
+            MainCat()
+        }
+
+        let animal = container.resolve(MainAnimal.self)
+        XCTAssertNil(animal?.name)
+    }
+
+    @MainActor
+    func testRegistersMainActorFactoryWithArgument() {
+        container.register(MainAnimal.self) { @MainActor _, arg1 in
+            MainCat(name: arg1)
+        }
+        let animal = container.resolve(MainAnimal.self, argument: "1")
+        XCTAssertEqual(animal?.name, "1")
+    }
+
+    @MainActor
+    func testRegistersMainActorFactoryWith3Arguments() {
+        container.register(MainAnimal.self) { @MainActor _, arg1, arg2, arg3 in
+            MainCat(name: arg1 + arg2 + arg3)
+        }
+        let animal = container.resolve(MainAnimal.self, arguments: "1", "2", "3")
+        XCTAssertEqual(animal?.name, "123")
+    }
+
+}
+
+@MainActor
+protocol MainAnimal {
+    var name: String? { get }
+}
+
+@MainActor
+private class MainCat: MainAnimal {
+    let name: String?
+
+    init() {
+        self.name = nil
+    }
+
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/script/gencode
+++ b/script/gencode
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files="Sources/Container.Arguments Sources/SynchronizedResolver.Arguments Sources/Resolver Sources/ServiceEntry.TypeForwarding"
+files="Sources/Container.Arguments Sources/Resolver Sources/ServiceEntry.TypeForwarding Sources/Container.MainActor"
 
 for file in $files; do
   echo "Generating code to $file.swift"


### PR DESCRIPTION
Adds an API to register services marked as `@MainActor` without build warnings or errors when strict concurrency is enabled. 

Examples of how this can be used to register a `@MainActor` isolated service.
```swift
container.register(MainService.self, mainActorFactory: { _ in MainService() })
container.register(MainService.self, factory: { _ in MainService() })
```

The resolution of services does not change but will crash if attempted off the main thread, effectively giving runtime concurrency safety. These new APIs will not be picked up automatically so there is no risk of a crash without a developer opting in to use strict concurrency.

The top 2 registrations demonstrate the new behaviour when using strict concurrency while the bottom demonstrates the old.

<img width="923" alt="Screenshot 2024-07-15 at 4 22 06 PM" src="https://github.com/user-attachments/assets/67f3eada-d0a7-4bcf-bff7-f8a87075e1ed">
