### PR TITLE
Fix ThreadSafety when registering and resolving at the same time on different threads.

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -20,7 +20,7 @@ import Foundation
 /// where `A` and `X` are protocols, `B` is a type conforming `A`, and `Y` is a type conforming `X`
 /// and depending on `A`.
 public final class Container {
-    internal var services = [ServiceKey: ServiceEntryProtocol]()
+    internal var services = ThreadSafeDictionary<ServiceKey, ServiceEntryProtocol>()
     private let parent: Container? // Used by HierarchyObjectScope
     private var resolutionDepth = 0
     private let debugHelper: DebugHelper
@@ -297,7 +297,7 @@ extension Container: _Resolver {
 
     fileprivate func getRegistrations() -> [ServiceKey: ServiceEntryProtocol] {
         var registrations = parent?.getRegistrations() ?? [:]
-        services.forEach { key, value in registrations[key] = value }
+        services.forEachRead { key, value in registrations[key] = value }
         return registrations
     }
 

--- a/Sources/ThreadSafeDictionary.swift
+++ b/Sources/ThreadSafeDictionary.swift
@@ -8,6 +8,12 @@ internal final class ThreadSafeDictionary<KeyType: Hashable, ValueType> {
 
     private let lock = ReadWriteLock()
 
+    public var values: Dictionary<KeyType, ValueType>.Values {
+        lock.read {
+            self.internalDictionary.values
+        }
+    }
+
     // MARK: - Initializers
 
     public init(dictionary: [KeyType: ValueType]? = nil) {
@@ -31,7 +37,7 @@ internal final class ThreadSafeDictionary<KeyType: Hashable, ValueType> {
             }
         }
     }
-    
+
     public subscript(key: KeyType, default defaultValue: @autoclosure () -> ValueType) -> ValueType? {
         get {
             return lock.read { self.internalDictionary[key, default: defaultValue()] }
@@ -49,10 +55,16 @@ internal final class ThreadSafeDictionary<KeyType: Hashable, ValueType> {
             self.internalDictionary.forEach(block)
         }
     }
-    
+
     public func forEachWrite(_ block: ((key: KeyType, value: ValueType)) -> Void) {
         lock.write {
             self.internalDictionary.forEach(block)
+        }
+    }
+
+    public func contains(where predicate: ((key: KeyType, value: ValueType)) -> Bool) -> Bool {
+        lock.read {
+            self.internalDictionary.contains(where: predicate)
         }
     }
 


### PR DESCRIPTION
Hello, as mentioned in this issue: https://github.com/Swinject/Swinject/issues/547
We encountered on our project some crashes when we try to resolve some dependencies while we are registering others on different threads. 

Here is what the stack trace of the different threads looks like (second one is the one crashing in this case).
![image](https://github.com/user-attachments/assets/46a0cf83-f29d-47c2-8c56-57bb9acb6be7)
![image](https://github.com/user-attachments/assets/96d13c3e-53e3-46b4-9fba-1553b99e6835)

Using the previously used ThreadSafeDictionary seem to fix the issue.