### PR TITLE
Allow access to ServiceEntry properties

### DIFF
--- a/Sources/Behavior.swift
+++ b/Sources/Behavior.swift
@@ -5,7 +5,7 @@
 /// Protocol for adding functionality to the container
 public protocol Behavior {
     /// This will be invoked on each behavior added to the `container` for each `entry` added to the container using
-    /// one of the `register()` or type forwading methods
+    /// one of the `register()` or type forwarding methods
     ///
     /// - Parameters:
     ///     - container: container into which an `entry` has been registered
@@ -13,7 +13,8 @@ public protocol Behavior {
     ///     - entry: ServiceEntry registered to the `container`
     ///     - name: name under which the service has been registered to the `container`
     ///
-    /// - Remark: `Type` and `Service` can be different types in the case of type forwarding
+    /// - Remark: `Type` and `Service` can be different types in the case of type forwarding (commonly used as `.implements()`).
+    /// `Type` will represent the forwarded type key, and `Service` will represent the destination.
     func container<Type, Service>(
         _ container: Container,
         didRegisterType type: Type.Type,

--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -18,7 +18,7 @@
 
 import Foundation
 
-// MARK: - Registeration with Arguments
+// MARK: - Registration with Arguments
 extension Container {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-// MARK: - Registeration with Arguments
+// MARK: - Registration with Arguments
 
 extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -18,8 +18,8 @@ internal protocol ServiceEntryProtocol: AnyObject {
 /// As a returned instance from ``Container/register(_:name:factory:)-8gy9r``, some configurations can be added.
 public final class ServiceEntry<Service>: ServiceEntryProtocol {
     fileprivate var initCompletedActions: [(Resolver, Service) -> Void] = []
-    internal let serviceType: Any.Type
-    internal let argumentsType: Any.Type
+    public let serviceType: Any.Type
+    public let argumentsType: Any.Type
 
     internal let factory: FunctionType
     internal weak var container: Container?


### PR DESCRIPTION
Container Behaviors receive instances of the `ServiceEntry` in its hook method, but are currently unable to access these properties.