### PR TITLE
feat(container): add resetObjectScope(_:serviceType:)

### DIFF
--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -97,7 +97,42 @@ public final class Container {
     public func resetObjectScope(_ objectScope: ObjectScope) {
         resetObjectScope(objectScope as ObjectScopeProtocol)
     }
+    /// Discards instances for a given service registered in the given `ObjectsScopeProtocol`.
+    ///
+    /// **Example usage:**
+    ///     container.resetObjectScope(ObjectScope.container, MyService.Type)
+    ///
+    /// - Parameters:
+    ///     - objectScope: instances registered in given `ObjectsScopeProtocol`
+    ///     - serviceType: and with given serviceType  will be discarded.
+    public func resetObjectScope(_ objectScope: ObjectScopeProtocol, serviceType: Any.Type) {
+        syncIfEnabled {
+            let matchingServices = services.keys
+                .filter { $0.serviceType == serviceType }
+                .compactMap { services[$0] }
 
+            if matchingServices.isEmpty { return }
+
+            matchingServices
+                .filter { $0.objectScope === objectScope }
+                .forEach { $0.storage.instance = nil }
+
+            parent?.resetObjectScope(objectScope, serviceType: serviceType)
+        }
+    }
+    /// Discards instances for  a given service registered in the given `ObjectsScope`. It performs the same operation
+    /// as `resetObjectScope(_:ObjectScopeProtocol, serviceType: Any.Type)`,
+    /// but provides more convenient usage syntax.
+    ///
+    /// **Example usage:**
+    ///     container.resetObjectScope(.container, servieType: MyService.self)
+    ///
+    /// - Parameters:
+    ///     - objectScope:  Instances registered in given `ObjectsScope`
+    ///     - serviceType:  and with given serviceType will be discarded.
+    public func resetObjectScope(_ objectScope: ObjectScope, serviceType: Any.Type) {
+        resetObjectScope(objectScope as ObjectScopeProtocol, serviceType: serviceType)
+    }
     /// Adds a registration for the specified service with the factory closure to specify how the service is
     /// resolved with dependencies.
     ///

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
@@ -26,8 +26,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EFE66E56E1E06404E473072E"
+            BuildableName = "Swinject.framework"
+            BlueprintName = "Swinject-iOS"
+            ReferencedContainer = "container:Swinject.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EFE66E56E1E06404E473072E"
-            BuildableName = "Swinject.framework"
-            BlueprintName = "Swinject-iOS"
-            ReferencedContainer = "container:Swinject.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +68,6 @@
             ReferencedContainer = "container:Swinject.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -90,8 +85,6 @@
             ReferencedContainer = "container:Swinject.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Tests/SwinjectTests/ContainerTests.CustomScope.swift
+++ b/Tests/SwinjectTests/ContainerTests.CustomScope.swift
@@ -83,8 +83,75 @@ class ContainerTests_CustomScope: XCTestCase {
 
         XCTAssertNil(storage.instance)
     }
-}
 
+    // MARK: Reseting scope with given Service Type
+
+    func testResetObjectScopeRemovesOnlyMatchingScopeInstances() {
+        let scope = ObjectScope.container
+
+        container.register(Foo.self) { _ in Foo() }.inObjectScope(scope)
+        let instance = container.resolve(Foo.self)
+
+        container.resetObjectScope(scope, serviceType: Foo.self)
+        let instanceAfterReset = container.resolve(Foo.self)
+
+        XCTAssertTrue(instance !== instanceAfterReset)
+    }
+    func testResetObjectScopeDoesNotRemoveInstancesOfDifferentScopes() {
+        let containerScope = ObjectScope.container
+        let graphScope = ObjectScope.graph
+
+        container.register(Foo.self, name: "containerScoped") { _ in Foo() }.inObjectScope(containerScope)
+        container.register(Foo.self, name: "graphScoped") { _ in Foo() }.inObjectScope(graphScope)
+
+        let containerInstance = container.resolve(Foo.self, name: "containerScoped")
+        let graphInstance = container.resolve(Foo.self, name: "graphScoped")
+
+        XCTAssertNotNil(graphInstance)
+
+        container.resetObjectScope(graphScope, serviceType: Foo.self)
+        let containerInstanceAfterReset = container.resolve(Foo.self, name: "containerScoped")  // container-scoped
+
+        XCTAssertTrue(containerInstance === containerInstanceAfterReset)
+    }
+    func testResetObjectScopeDoesNotRemoveInstancesOfDifferentTypes() {
+        let scope = ObjectScope.container
+
+        container.register(Foo.self) { _ in Foo() }.inObjectScope(scope)
+        container.register(Bar.self) { _ in Bar() }.inObjectScope(scope)
+
+        let fooInstance = container.resolve(Foo.self)
+        let barInstance = container.resolve(Bar.self)
+
+        container.resetObjectScope(scope, serviceType: Foo.self)
+        let newFooInstance = container.resolve(Foo.self)
+        let newBarInstance = container.resolve(Bar.self)
+
+        XCTAssertTrue(fooInstance !== newFooInstance)
+        XCTAssertTrue(barInstance === newBarInstance)
+    }
+    func testResetObjectScopeCallsParentContainer() {
+        let parentContainer = Container()
+        let childContainer = Container(parent: parentContainer)
+
+        let scope = ObjectScope.container
+
+        parentContainer.register(Foo.self) { _ in Foo() }.inObjectScope(scope)
+        childContainer.register(Foo.self) { _ in Foo() }.inObjectScope(scope)
+
+        let parentInstance = parentContainer.resolve(Foo.self)
+        let childInstance = childContainer.resolve(Foo.self)
+
+        childContainer.resetObjectScope(scope, serviceType: Foo.self)
+        let newParentInstance = parentContainer.resolve(Foo.self)
+        let newChildInstance = childContainer.resolve(Foo.self)
+
+        XCTAssertFalse(childInstance === newChildInstance)
+        XCTAssertFalse(parentInstance === newParentInstance)
+    }
+}
+private class Foo {}
+private class Bar {}
 private class FakeStorage: InstanceStorage {
     var instance: Any?
 }


### PR DESCRIPTION

Enhances resetObjectScope to allow clearing cached instances for a specific service type instead of resetting all instances within the given scope. This provides more granular control over instance lifecycle management.